### PR TITLE
Fix duplicate auto-migrations 

### DIFF
--- a/dbwarden/commands/make_migrations.py
+++ b/dbwarden/commands/make_migrations.py
@@ -142,11 +142,25 @@ def generate_migration_sql(
     except Exception:
         existing_tables = {}
 
+    migration_tables = {}
+    if migrations_dir:
+        migration_tables = extract_tables_from_migrations(migrations_dir)
+
+    known_tables: dict[str, set[str]] = {
+        table_name: {col.lower() for col in columns}
+        for table_name, columns in existing_tables.items()
+    }
+    for table_name, columns in migration_tables.items():
+        if table_name in known_tables:
+            known_tables[table_name].update({col.lower() for col in columns})
+        else:
+            known_tables[table_name] = {col.lower() for col in columns}
+
     upgrade_parts = []
     rollback_parts = []
 
     for table in tables:
-        existing_columns = existing_tables.get(table.name, set())
+        existing_columns = known_tables.get(table.name, set())
 
         if not existing_columns:
             create_sql = generate_create_table_sql(table)
@@ -161,7 +175,23 @@ def generate_migration_sql(
                         f"ALTER TABLE {table.name} DROP COLUMN {column.name}"
                     )
 
+                    known_tables.setdefault(table.name, set()).add(column.name.lower())
+
     rollback_parts.reverse()
+
+    if migrations_dir:
+        existing_statements = get_pending_migration_statements(migrations_dir)
+        filtered_upgrade_parts = []
+        filtered_rollback_parts = []
+
+        for upgrade_sql, rollback_sql in zip(upgrade_parts, rollback_parts):
+            if upgrade_sql.strip() in existing_statements:
+                continue
+            filtered_upgrade_parts.append(upgrade_sql)
+            filtered_rollback_parts.append(rollback_sql)
+
+        upgrade_parts = filtered_upgrade_parts
+        rollback_parts = filtered_rollback_parts
 
     return "\n\n".join(upgrade_parts), "\n\n".join(rollback_parts)
 

--- a/tests/test_make_migrations.py
+++ b/tests/test_make_migrations.py
@@ -1,0 +1,80 @@
+import os
+import tempfile
+
+from dbwarden.commands.make_migrations import generate_migration_sql
+from dbwarden.engine.model_discovery import ModelColumn, ModelTable
+
+
+def _write_migration(directory: str, name: str, content: str) -> None:
+    with open(os.path.join(directory, name), "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+def test_generate_migration_sql_skips_duplicate_create_from_pending_migration():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_migration(
+            tmpdir,
+            "0002_auto_generated.sql",
+            """-- upgrade
+
+CREATE TABLE IF NOT EXISTS uploads (
+    upload_id UUID NOT NULL PRIMARY KEY,
+    user_id VARCHAR NOT NULL,
+    filename VARCHAR NOT NULL
+)
+
+-- rollback
+
+DROP TABLE uploads
+""",
+        )
+
+        table = ModelTable(
+            name="uploads",
+            columns=[
+                ModelColumn("upload_id", "UUID", False, True, False, None, None),
+                ModelColumn("user_id", "VARCHAR", False, False, False, None, None),
+                ModelColumn("filename", "VARCHAR", False, False, False, None, None),
+            ],
+        )
+
+        upgrade_sql, rollback_sql = generate_migration_sql(
+            [table], migrations_dir=tmpdir
+        )
+
+        assert upgrade_sql.strip() == ""
+        assert rollback_sql.strip() == ""
+
+
+def test_generate_migration_sql_uses_pending_migrations_as_schema_source():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_migration(
+            tmpdir,
+            "0001_create_users.sql",
+            """-- upgrade
+
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER NOT NULL PRIMARY KEY
+)
+
+-- rollback
+
+DROP TABLE users
+""",
+        )
+
+        table = ModelTable(
+            name="users",
+            columns=[
+                ModelColumn("id", "INTEGER", False, True, False, None, None),
+                ModelColumn("email", "VARCHAR(255)", False, False, True, None, None),
+            ],
+        )
+
+        upgrade_sql, rollback_sql = generate_migration_sql(
+            [table], migrations_dir=tmpdir
+        )
+
+        assert "ALTER TABLE users ADD COLUMN email" in upgrade_sql
+        assert "CREATE TABLE IF NOT EXISTS users" not in upgrade_sql
+        assert "ALTER TABLE users DROP COLUMN email" in rollback_sql


### PR DESCRIPTION
Improved make-migrations logic to check both:
  - current database schema, and
  - previously generated migration files  
so duplicate pending migrations are no longer generated.