### PR TITLE
Feat: add migration plan output and configurable migration tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ class User(Base):
 dbwarden make-migrations "create users table"
 ```
 
-DBWarden creates a versioned SQL file with both upgrade and rollback:
+DBWarden creates a versioned SQL file plus a companion `.plan.json` file.
+
+The SQL file contains both upgrade and rollback:
 
 ```sql
 -- upgrade
@@ -114,6 +116,8 @@ CREATE TABLE IF NOT EXISTS users (
 
 DROP TABLE users;
 ```
+
+The plan file contains machine-readable metadata about the generated operations and checksum. Use `dbwarden make-migrations --plan` to print that JSON without writing files.
 
 ### 4. Apply
 

--- a/dbwarden/cli/main.py
+++ b/dbwarden/cli/main.py
@@ -209,13 +209,23 @@ def make_migrations(
     verbose: bool = typer.Option(
         False, "--verbose", "-v", help="Enable verbose logging"
     ),
+    plan: bool = typer.Option(
+        False,
+        "--plan",
+        help="Output migration plan JSON without writing files",
+    ),
     database: str | None = typer.Option(
         None, "--database", "-d", help="Target database name"
     ),
 ):
     """Auto-generate SQL migration from SQLAlchemy models."""
     validate_directory()
-    handle_make_migrations(description=description, verbose=verbose, database=database)
+    handle_make_migrations(
+        description=description,
+        verbose=verbose,
+        database=database,
+        output_plan=plan,
+    )
 
 
 @app.command()

--- a/dbwarden/commands/__init__.py
+++ b/dbwarden/commands/__init__.py
@@ -60,10 +60,18 @@ def handle_init(database: str | None = None) -> None:
 
 
 def handle_make_migrations(
-    description: str | None, verbose: bool, database: str | None = None
+    description: str | None,
+    verbose: bool,
+    database: str | None = None,
+    output_plan: bool = False,
 ) -> None:
     """Handle make-migrations command."""
-    make_migrations_cmd(description=description, verbose=verbose, database=database)
+    make_migrations_cmd(
+        description=description,
+        verbose=verbose,
+        database=database,
+        output_plan=output_plan,
+    )
 
 
 def handle_new(

--- a/dbwarden/commands/make_migrations.py
+++ b/dbwarden/commands/make_migrations.py
@@ -1,10 +1,12 @@
 import os
 import re
+import json
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
 from dbwarden.config import get_database, get_multi_db_config
+from dbwarden.engine.checksum import calculate_checksum
 from dbwarden.engine.file_parser import parse_upgrade_statements
 from dbwarden.engine.model_discovery import (
     get_all_model_tables,
@@ -58,6 +60,7 @@ def make_migrations_cmd(
     description: str | None = None,
     verbose: bool = False,
     database: str | None = None,
+    output_plan: bool = False,
 ) -> None:
     """
     Auto-generate SQL migration from SQLAlchemy models.
@@ -66,6 +69,7 @@ def make_migrations_cmd(
         description: Description for the migration.
         verbose: Enable verbose logging.
         database: Target database name.
+        output_plan: Print the migration plan JSON without writing files.
     """
     logger = get_logger()
 
@@ -105,6 +109,18 @@ def make_migrations_cmd(
         tables, migrations_dir, database, db_name
     )
 
+    safe_desc = _resolve_migration_description(description, changes)
+    filename = generate_migration_filename(db_name, safe_desc, next_number)
+    plan = build_migration_plan(
+        migration_id=Path(filename).stem,
+        changes=changes,
+        upgrade_sql=upgrade_sql,
+    )
+
+    if output_plan:
+        console.print(json.dumps(plan, indent=2), markup=False, highlight=False)
+        return
+
     if not upgrade_sql.strip():
         console.print(
             "No new migrations to generate - all models already covered by existing migrations.",
@@ -112,15 +128,8 @@ def make_migrations_cmd(
         )
         return
 
-    if description is None and changes:
-        safe_desc = autogenerate_migration_name(changes)
-        if not safe_desc:
-            safe_desc = "auto_generated"
-    else:
-        safe_desc = re.sub(r"[^a-zA-Z0-9]", "_", description or "auto_generated").lower()
-
-    filename = generate_migration_filename(db_name, safe_desc, next_number)
     filepath = os.path.join(migrations_dir, filename)
+    plan_filepath = str(Path(filepath).with_suffix(".plan.json"))
 
     # Validate the final path stays within migrations directory
     migrations_dir_canonical = os.path.realpath(migrations_dir)
@@ -143,9 +152,52 @@ def make_migrations_cmd(
     with open(filepath, "w") as f:
         f.write(content)
 
+    with open(plan_filepath, "w", encoding="utf-8") as f:
+        json.dump(plan, f, indent=2)
+        f.write("\n")
+
     logger.info(f"Created migration file: {filename}")
     console.print(f"Created migration file: {filepath}", style="green")
+    console.print(f"Created migration plan: {plan_filepath}", style="green")
     console.print(f"Tables included: {', '.join(t.name for t in tables)}", style="cyan")
+
+
+def _resolve_migration_description(
+    description: str | None,
+    changes: list[Change],
+) -> str:
+    if description is None and changes:
+        safe_desc = autogenerate_migration_name(changes)
+        if not safe_desc:
+            safe_desc = "auto_generated"
+        return safe_desc
+    return re.sub(r"[^a-zA-Z0-9]", "_", description or "auto_generated").lower()
+
+
+def build_migration_plan(
+    migration_id: str,
+    changes: list[Change],
+    upgrade_sql: str,
+) -> dict[str, object]:
+    operations = [_build_plan_operation(change) for change in changes]
+    checksum = calculate_checksum([upgrade_sql]) if upgrade_sql.strip() else calculate_checksum([])
+    return {
+        "migration_id": migration_id,
+        "operations": operations,
+        "required_flags": [],
+        "checksum": checksum,
+    }
+
+
+def _build_plan_operation(change: Change) -> dict[str, str]:
+    operation = {
+        "type": change.operation,
+        "table": change.table,
+        "severity": "INFO",
+    }
+    if change.target:
+        operation["column"] = change.target
+    return operation
 
 
 def generate_migration_sql(

--- a/dbwarden/commands/settings.py
+++ b/dbwarden/commands/settings.py
@@ -67,6 +67,7 @@ def _entry_kwargs(entry: DatabaseEntry) -> dict[str, Any]:
         "secure_values": entry.secure_values,
         "default": entry.default,
         "migrations_dir": entry.migrations_dir,
+        "migration_table": entry.migration_table,
         "model_paths": entry.model_paths,
         "dev_database_type": entry.dev_database_type,
         "dev_database_url": entry.dev_database_url,
@@ -83,6 +84,7 @@ def _render_entry(entry: DatabaseEntry) -> str:
         "database_url",
         "secure_values",
         "migrations_dir",
+        "migration_table",
         "model_paths",
         "dev_database_type",
         "dev_database_url",
@@ -167,6 +169,10 @@ def handle_settings_show(database: str | None = None, all_databases: bool = Fals
                 "Migrations Directory",
                 display_value(db, "migrations_dir", db.migrations_dir),
             )
+            _print_field(
+                "Migration Table",
+                display_value(db, "migration_table", db.migration_table),
+            )
             _print_field("Model Paths", display_value(db, "model_paths", db.model_paths))
             _print_field(
                 "Dev Database Type",
@@ -199,6 +205,10 @@ def handle_settings_show(database: str | None = None, all_databases: bool = Fals
     _print_field(
         "Migrations Directory",
         display_value(db, "migrations_dir", db.migrations_dir),
+    )
+    _print_field(
+        "Migration Table",
+        display_value(db, "migration_table", db.migration_table),
     )
     _print_field("Model Paths", display_value(db, "model_paths", db.model_paths))
     _print_field(
@@ -234,6 +244,7 @@ def handle_settings_database_add(
     database_type: str,
     url: str,
     migrations_dir: str | None = None,
+    migration_table: str | None = None,
     model_paths: list[str] | None = None,
     dev_type: str | None = None,
     dev_url: str | None = None,
@@ -254,6 +265,7 @@ def handle_settings_database_add(
             "database_type": database_type,
             "database_url": url,
             "migrations_dir": migrations_dir,
+            "migration_table": migration_table,
             "model_paths": model_paths,
             "dev_database_type": dev_type,
             "dev_database_url": dev_url,

--- a/dbwarden/commands/utils.py
+++ b/dbwarden/commands/utils.py
@@ -34,6 +34,10 @@ def config_cmd() -> None:
             f"    migrations_dir: {display_value(db, 'migrations_dir', db.migrations_dir)}",
             style="white",
         )
+        console.print(
+            f"    migration_table: {display_value(db, 'migration_table', db.migration_table)}",
+            style="white",
+        )
         if db.model_paths:
             console.print(
                 f"    model_paths: {display_value(db, 'model_paths', db.model_paths)}",

--- a/dbwarden/config.py
+++ b/dbwarden/config.py
@@ -15,6 +15,7 @@ from dbwarden.constants import TOML_FILE
 from dbwarden.exceptions import ConfigurationError
 
 DatabaseType = Literal["sqlite", "postgresql", "mysql", "mariadb", "clickhouse"]
+DEFAULT_MIGRATION_TABLE = "_dbwarden_migrations"
 
 _IGNORE_DIRS = {
     ".git",
@@ -38,6 +39,7 @@ class DatabaseConfig:
     secure_display_values: dict[str, str] = field(default_factory=dict)
     model_paths: list[str] | None = None
     migrations_dir: str = "migrations"
+    migration_table: str = DEFAULT_MIGRATION_TABLE
     postgres_schema: str | None = None
     dev_database_url: str | None = None
     dev_database_type: DatabaseType | None = None
@@ -410,6 +412,7 @@ def _finalize_entries(
             secure_display_values=secure_display_values,
             model_paths=entry.model_paths,
             migrations_dir=migrations_dir,
+            migration_table=entry.migration_table or DEFAULT_MIGRATION_TABLE,
             postgres_schema=None,
             dev_database_url=entry.dev_database_url,
             dev_database_type=entry.dev_database_type,

--- a/dbwarden/config_schema.py
+++ b/dbwarden/config_schema.py
@@ -16,6 +16,7 @@ VALID_DATABASE_TYPES = frozenset(
 
 DATABASE_NAME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*$")
 MODEL_PATH_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_/]*$")
+IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 MAX_PATH_LENGTH = 200
 MAX_PATH_COUNT = 10
 
@@ -59,6 +60,19 @@ def _validate_database_type(_self, _attribute, value: str) -> None:
         )
 
 
+def _validate_identifier_field(field_name: str, value: str) -> None:
+    if not value or not IDENTIFIER_RE.match(value):
+        raise ValueError(
+            f"Invalid {field_name} '{value}'. Must start with letter/underscore and contain only alphanumeric or underscore."
+        )
+
+
+def _validate_migration_table(_self, _attribute, value: str | None) -> None:
+    if value is None:
+        return
+    _validate_identifier_field("migration_table", value)
+
+
 @define(slots=False)
 class DatabaseEntry:
     database_name: str = field(validator=_validate_database_name)
@@ -67,6 +81,7 @@ class DatabaseEntry:
     secure_values: bool = False
     default: bool = False
     migrations_dir: str | None = None
+    migration_table: str | None = field(default=None, validator=_validate_migration_table)
     model_paths: list[str] | None = None
     dev_database_type: DatabaseType | None = None
     dev_database_url: str | None = None

--- a/dbwarden/database/queries.py
+++ b/dbwarden/database/queries.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 from sqlalchemy.engine import make_url
 
-from dbwarden.config import get_database
+from dbwarden.config import DEFAULT_MIGRATION_TABLE, get_database
 
 
 class QueryMethod(Enum):
@@ -31,7 +31,7 @@ class QueryMethod(Enum):
 
 SQLITE_QUERIES = {
     QueryMethod.CREATE_MIGRATIONS_TABLE: """
-        CREATE TABLE IF NOT EXISTS dbwarden_migrations (
+        CREATE TABLE IF NOT EXISTS {migration_table} (
             version VARCHAR(255),
             description VARCHAR(500),
             filename VARCHAR(500) UNIQUE,
@@ -48,29 +48,29 @@ SQLITE_QUERIES = {
         )
     """,
     QueryMethod.INSERT_VERSION: """
-        INSERT INTO dbwarden_migrations (version, description, filename, migration_type, checksum)
+        INSERT INTO {migration_table} (version, description, filename, migration_type, checksum)
         VALUES (:version, :description, :filename, :migration_type, :checksum)
     """,
     QueryMethod.DELETE_VERSION: """
-        DELETE FROM dbwarden_migrations WHERE version = :version
+        DELETE FROM {migration_table} WHERE version = :version
     """,
     QueryMethod.GET_ALL_MIGRATIONS: """
-        SELECT * FROM dbwarden_migrations ORDER BY applied_at ASC
+        SELECT * FROM {migration_table} ORDER BY applied_at ASC
     """,
     QueryMethod.GET_LATEST_VERSION: """
-        SELECT * FROM dbwarden_migrations
+        SELECT * FROM {migration_table}
         WHERE version IS NOT NULL
         ORDER BY applied_at DESC
         LIMIT 1
     """,
     QueryMethod.GET_MIGRATED_VERSIONS: """
-        SELECT version FROM dbwarden_migrations WHERE version IS NOT NULL ORDER BY applied_at ASC
+        SELECT version FROM {migration_table} WHERE version IS NOT NULL ORDER BY applied_at ASC
     """,
     QueryMethod.CHECK_IF_MIGRATIONS_TABLE_EXISTS: """
-        SELECT name FROM sqlite_master WHERE type='table' AND name='dbwarden_migrations'
+        SELECT name FROM sqlite_master WHERE type='table' AND name='{migration_table}'
     """,
     QueryMethod.CHECK_IF_VERSION_EXISTS: """
-        SELECT COUNT(*) FROM dbwarden_migrations WHERE version = :version
+        SELECT COUNT(*) FROM {migration_table} WHERE version = :version
     """,
     QueryMethod.ACQUIRE_LOCK: """
         INSERT OR REPLACE INTO dbwarden_lock (id, locked, acquired_at)
@@ -93,20 +93,20 @@ SQLITE_QUERIES = {
         SELECT name, sql FROM sqlite_master WHERE type='index' AND tbl_name=:table_name
     """,
     QueryMethod.GET_RUNS_ON_CHANGE_CHECKSUMS: """
-        SELECT filename, checksum FROM dbwarden_migrations
+        SELECT filename, checksum FROM {migration_table}
         WHERE migration_type = 'runs_on_change'
     """,
     QueryMethod.GET_RUNS_ALWAYS_FILENAMES: """
-        SELECT filename FROM dbwarden_migrations
+        SELECT filename FROM {migration_table}
         WHERE migration_type = 'runs_always'
     """,
     QueryMethod.UPSERT_REPEATABLE_MIGRATION: """
-        INSERT OR REPLACE INTO dbwarden_migrations
+        INSERT OR REPLACE INTO {migration_table}
         (version, description, filename, migration_type, checksum)
         VALUES (NULL, :description, :filename, :migration_type, :checksum)
     """,
     QueryMethod.DELETE_REPEATABLE_BY_FILENAME: """
-        DELETE FROM dbwarden_migrations
+        DELETE FROM {migration_table}
         WHERE filename = :filename AND migration_type IN ('runs_always', 'runs_on_change')
     """,
 }
@@ -114,7 +114,7 @@ SQLITE_QUERIES = {
 
 POSTGRES_QUERIES = {
     QueryMethod.CREATE_MIGRATIONS_TABLE: """
-        CREATE TABLE IF NOT EXISTS dbwarden_migrations (
+        CREATE TABLE IF NOT EXISTS {migration_table} (
             version VARCHAR(255) UNIQUE,
             description VARCHAR(500),
             filename VARCHAR(500) UNIQUE,
@@ -131,7 +131,7 @@ POSTGRES_QUERIES = {
         )
     """,
     QueryMethod.INSERT_VERSION: """
-        INSERT INTO dbwarden_migrations (version, description, filename, migration_type, checksum)
+        INSERT INTO {migration_table} (version, description, filename, migration_type, checksum)
         VALUES (:version, :description, :filename, :migration_type, :checksum)
         ON CONFLICT (version) DO UPDATE SET
             checksum = EXCLUDED.checksum,
@@ -145,7 +145,7 @@ POSTGRES_QUERIES = {
     ],
     QueryMethod.CHECK_IF_MIGRATIONS_TABLE_EXISTS: """
         SELECT tablename FROM pg_catalog.pg_tables
-        WHERE schemaname = current_schema() AND tablename = 'dbwarden_migrations'
+        WHERE schemaname = current_schema() AND tablename = '{migration_table}'
     """,
     QueryMethod.CHECK_IF_VERSION_EXISTS: SQLITE_QUERIES[
         QueryMethod.CHECK_IF_VERSION_EXISTS
@@ -187,7 +187,7 @@ POSTGRES_QUERIES = {
         QueryMethod.GET_RUNS_ALWAYS_FILENAMES
     ],
     QueryMethod.UPSERT_REPEATABLE_MIGRATION: """
-        INSERT INTO dbwarden_migrations
+        INSERT INTO {migration_table}
         (version, description, filename, migration_type, checksum)
         VALUES (NULL, :description, :filename, :migration_type, :checksum)
         ON CONFLICT (filename)
@@ -205,7 +205,7 @@ POSTGRES_QUERIES = {
 
 MYSQL_QUERIES = {
     QueryMethod.CREATE_MIGRATIONS_TABLE: """
-        CREATE TABLE IF NOT EXISTS dbwarden_migrations (
+        CREATE TABLE IF NOT EXISTS {migration_table} (
             version VARCHAR(255),
             description VARCHAR(500),
             filename VARCHAR(500) UNIQUE,
@@ -231,7 +231,7 @@ MYSQL_QUERIES = {
     QueryMethod.CHECK_IF_MIGRATIONS_TABLE_EXISTS: """
         SELECT table_name AS name
         FROM information_schema.tables
-        WHERE table_schema = DATABASE() AND table_name = 'dbwarden_migrations'
+        WHERE table_schema = DATABASE() AND table_name = '{migration_table}'
     """,
     QueryMethod.CHECK_IF_VERSION_EXISTS: SQLITE_QUERIES[
         QueryMethod.CHECK_IF_VERSION_EXISTS
@@ -275,7 +275,7 @@ MYSQL_QUERIES = {
         QueryMethod.GET_RUNS_ALWAYS_FILENAMES
     ],
     QueryMethod.UPSERT_REPEATABLE_MIGRATION: """
-        INSERT INTO dbwarden_migrations
+        INSERT INTO {migration_table}
         (version, description, filename, migration_type, checksum)
         VALUES (NULL, :description, :filename, :migration_type, :checksum)
         ON DUPLICATE KEY UPDATE
@@ -292,7 +292,7 @@ MYSQL_QUERIES = {
 
 CLICKHOUSE_QUERIES = {
     QueryMethod.CREATE_MIGRATIONS_TABLE: """
-        CREATE TABLE IF NOT EXISTS dbwarden_migrations (
+        CREATE TABLE IF NOT EXISTS {migration_table} (
             version String,
             description String,
             filename String,
@@ -311,35 +311,35 @@ CLICKHOUSE_QUERIES = {
         ORDER BY id
     """,
     QueryMethod.INSERT_VERSION: """
-        INSERT INTO dbwarden_migrations (version, description, filename, migration_type, checksum)
+        INSERT INTO {migration_table} (version, description, filename, migration_type, checksum)
         VALUES (:version, :description, :filename, :migration_type, :checksum)
     """,
     QueryMethod.DELETE_VERSION: """
-        ALTER TABLE dbwarden_migrations DELETE WHERE version = :version
+        ALTER TABLE {migration_table} DELETE WHERE version = :version
     """,
     QueryMethod.GET_ALL_MIGRATIONS: """
         SELECT version, description, filename, migration_type, applied_at, checksum
-        FROM dbwarden_migrations
+        FROM {migration_table}
         ORDER BY applied_at ASC
     """,
     QueryMethod.GET_LATEST_VERSION: """
         SELECT version, description, filename, migration_type, applied_at, checksum
-        FROM dbwarden_migrations
+        FROM {migration_table}
         WHERE version IS NOT NULL
         ORDER BY applied_at DESC
         LIMIT 1
     """,
     QueryMethod.GET_MIGRATED_VERSIONS: """
-        SELECT version FROM dbwarden_migrations
+        SELECT version FROM {migration_table}
         WHERE version IS NOT NULL
         ORDER BY applied_at ASC
     """,
     QueryMethod.CHECK_IF_MIGRATIONS_TABLE_EXISTS: """
         SELECT name FROM system.tables
-        WHERE database = currentDatabase() AND name = 'dbwarden_migrations'
+        WHERE database = currentDatabase() AND name = '{migration_table}'
     """,
     QueryMethod.CHECK_IF_VERSION_EXISTS: """
-        SELECT count() FROM dbwarden_migrations WHERE version = :version
+        SELECT count() FROM {migration_table} WHERE version = :version
     """,
     QueryMethod.ACQUIRE_LOCK: """
         ALTER TABLE dbwarden_lock UPDATE locked = 1, acquired_at = now() WHERE id = 1
@@ -365,19 +365,19 @@ CLICKHOUSE_QUERIES = {
         WHERE database = currentDatabase() AND table = :table_name
     """,
     QueryMethod.GET_RUNS_ON_CHANGE_CHECKSUMS: """
-        SELECT filename, checksum FROM dbwarden_migrations
+        SELECT filename, checksum FROM {migration_table}
         WHERE migration_type = 'runs_on_change'
     """,
     QueryMethod.GET_RUNS_ALWAYS_FILENAMES: """
-        SELECT filename FROM dbwarden_migrations
+        SELECT filename FROM {migration_table}
         WHERE migration_type = 'runs_always'
     """,
     QueryMethod.UPSERT_REPEATABLE_MIGRATION: """
-        INSERT INTO dbwarden_migrations (version, description, filename, migration_type, checksum)
+        INSERT INTO {migration_table} (version, description, filename, migration_type, checksum)
         VALUES (NULL, :description, :filename, :migration_type, :checksum)
     """,
     QueryMethod.DELETE_REPEATABLE_BY_FILENAME: """
-        ALTER TABLE dbwarden_migrations DELETE WHERE filename = :filename AND migration_type IN ('runs_always', 'runs_on_change')
+        ALTER TABLE {migration_table} DELETE WHERE filename = :filename AND migration_type IN ('runs_always', 'runs_on_change')
     """,
 }
 
@@ -401,7 +401,16 @@ def _get_queries_for_backend(db_name: str | None = None) -> dict:
     return SQLITE_QUERIES
 
 
+def get_migration_table_name(db_name: str | None = None) -> str:
+    try:
+        return get_database(db_name).migration_table
+    except Exception:
+        return DEFAULT_MIGRATION_TABLE
+
+
 def get_query(method: QueryMethod, db_name: str | None = None, **kwargs) -> str:
     """Get a SQL query by method for current backend."""
-
-    return _get_queries_for_backend(db_name).get(method, "")
+    query = _get_queries_for_backend(db_name).get(method, "")
+    if not query:
+        return ""
+    return query.format(migration_table=get_migration_table_name(db_name), **kwargs)

--- a/dbwarden/repositories/migrations_repo.py
+++ b/dbwarden/repositories/migrations_repo.py
@@ -4,7 +4,7 @@ from sqlalchemy import Result, Row, text
 from sqlalchemy.orm import Session
 
 from dbwarden.database.connection import get_db_connection
-from dbwarden.database.queries import QueryMethod, get_query
+from dbwarden.database.queries import QueryMethod, get_migration_table_name, get_query
 from dbwarden.models import MigrationRecord
 
 
@@ -143,9 +143,10 @@ def get_applied_checksums(db_name: str | None = None) -> set[str]:
         return set()
 
     with get_db_connection(db_name) as connection:
+        migration_table = get_migration_table_name(db_name)
         results = connection.execute(
             text(
-                "SELECT DISTINCT checksum FROM dbwarden_migrations WHERE checksum IS NOT NULL"
+                f"SELECT DISTINCT checksum FROM {migration_table} WHERE checksum IS NOT NULL"
             )
         )
         return {row.checksum for row in results.fetchall()}
@@ -159,18 +160,20 @@ def get_latest_versions(
     """Get recent migration versions."""
     if limit:
         with get_db_connection(db_name) as connection:
+            migration_table = get_migration_table_name(db_name)
             result = connection.execute(
                 text(
-                    f"SELECT version FROM dbwarden_migrations WHERE version IS NOT NULL ORDER BY applied_at DESC LIMIT :limit"
+                    f"SELECT version FROM {migration_table} WHERE version IS NOT NULL ORDER BY applied_at DESC LIMIT :limit"
                 ),
                 parameters={"limit": limit},
             )
             return [row.version for row in result.fetchall()]
     elif starting_version:
         with get_db_connection(db_name) as connection:
+            migration_table = get_migration_table_name(db_name)
             result = connection.execute(
                 text(
-                    "SELECT version FROM dbwarden_migrations WHERE version > :starting_version AND version IS NOT NULL ORDER BY applied_at ASC"
+                    f"SELECT version FROM {migration_table} WHERE version > :starting_version AND version IS NOT NULL ORDER BY applied_at ASC"
                 ),
                 parameters={"starting_version": starting_version},
             )

--- a/docs/architecture-deep-dive.md
+++ b/docs/architecture-deep-dive.md
@@ -58,6 +58,7 @@ Rollback uses the same lock discipline, selecting rollback SQL from applied file
 4. compare against known schema state (database + migration history)
 5. generate upgrade and rollback SQL
 6. write migration file
+7. write companion `.plan.json` metadata file
 
 ## Repeatable migration model
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -90,9 +90,10 @@ dbwarden settings database-clear-dev primary
 ```bash
 dbwarden make-migrations "create users table" --database primary
 dbwarden make-migrations --verbose --database primary
+dbwarden make-migrations --plan --database primary
 ```
 
-Options: `--database`, `--verbose`
+Options: `--database`, `--plan`, `--verbose`
 
 ### `new`
 

--- a/docs/commands/make-migrations.md
+++ b/docs/commands/make-migrations.md
@@ -13,13 +13,50 @@ dbwarden make-migrations "create users table"
 
 # With database option
 dbwarden make-migrations --database primary --verbose
+
+# Output plan JSON only
+dbwarden make-migrations --database primary --plan
 ```
 
 ## Options
 
 - `description` (optional) - Custom migration name. If not provided, automatically generated from schema changes
 - `--database`, `-d` - Target database
+- `--plan` - Print the migration plan JSON without writing files
 - `--verbose`, `-v` - Verbose output
+
+## Generated artifacts
+
+When a migration is generated, DBWarden writes two files side by side:
+
+- `{database_name}__{version}_{description}.sql`
+- `{database_name}__{version}_{description}.plan.json`
+
+The companion plan file contains machine-readable metadata about the generated migration, including:
+
+- `migration_id`
+- `operations`
+- `required_flags`
+- `checksum`
+
+Example:
+
+```json
+{
+  "migration_id": "primary__0001_create_users",
+  "operations": [
+    {
+      "type": "create_table",
+      "table": "users",
+      "severity": "INFO"
+    }
+  ],
+  "required_flags": [],
+  "checksum": "sha256..."
+}
+```
+
+`--plan` switches the command into JSON-output mode. In that mode DBWarden prints the plan to stdout and does not write the `.sql` or `.plan.json` files.
 
 ## Auto-Generated Names
 
@@ -45,22 +82,23 @@ When no description is provided, DBWarden automatically generates a descriptive 
 ## Examples
 
 ```bash
-# Creates 0001_create_table_users.sql
-dbwarden make-migrations
+# Creates primary__0001_create_table_users.sql and primary__0001_create_table_users.plan.json
+dbwarden make-migrations --database primary
 
-# Creates 0002_add_column_users_email.sql  
-dbwarden make-migrations
+# Creates primary__0002_add_column_users_email.sql and primary__0002_add_column_users_email.plan.json
+dbwarden make-migrations --database primary
 
-# Creates 0003_add_columns_users_email_name.sql
-dbwarden make-migrations
+# Creates primary__0003_add_columns_users_email_name.sql and primary__0003_add_columns_users_email_name.plan.json
+dbwarden make-migrations --database primary
 
 # Uses custom name
-dbwarden make-migrations -d initial_schema
+dbwarden make-migrations "initial_schema" --database primary
 ```
 
 ## Notes
 
 - Generated file includes both `-- upgrade` and `-- rollback`
+- Generated `.plan.json` files are useful for CI checks and debugging
 - If no models are discovered, configure `model_paths` explicitly
 - with `--dev`, translation can target dev SQLite behavior
 

--- a/docs/fastapi/health-router.md
+++ b/docs/fastapi/health-router.md
@@ -193,12 +193,12 @@ For each database, the health check runs:
 1. Attempt connection using the cached engine (or build one if not yet cached)
 2. Execute a trivial connectivity query (`SELECT 1`)
 3. If connectivity fails → mark `connected=False`, `status="error"`, set `error` field, skip migration check
-4. If connectivity succeeds → query `dbwarden_migrations` table to count applied migrations
+4. If connectivity succeeds → query the configured migration tracking table (default: `_dbwarden_migrations`) to count applied migrations
 5. Compare applied count against discovered migration files to compute `pending_migrations`
-6. Check if `dbwarden_migrations_lock` table has an active lock
+6. Check if `dbwarden_lock` table has an active lock
 7. Return health result
 
-If `dbwarden_migrations` table does not exist → `pending_migrations` is the total migration file count (nothing has been applied yet).
+If the migration tracking table does not exist → `pending_migrations` is the total migration file count (nothing has been applied yet).
 
 ## Use cases
 

--- a/docs/fastapi/tutorial/health-endpoints.md
+++ b/docs/fastapi/tutorial/health-endpoints.md
@@ -226,7 +226,7 @@ For **each database**, DBWarden checks:
 3. **Migration lock** - Is a migration currently running?
 
 !!! info "Performance"
-    Health checks are fast - they only run `SELECT 1` and query the `dbwarden_migrations` table. No expensive queries or full schema scans.
+    Health checks are fast - they only run `SELECT 1` and query the configured migration tracking table (default: `_dbwarden_migrations`). No expensive queries or full schema scans.
 
 ## Common Use Cases
 

--- a/docs/migration-files.md
+++ b/docs/migration-files.md
@@ -22,6 +22,14 @@ primary__0002_add_users_table.sql
 analytics__0001_create_events.sql
 ```
 
+When a migration is auto-generated with `make-migrations`, DBWarden also writes a companion plan file:
+
+```text
+primary__0001_initial_schema.plan.json
+```
+
+That file captures machine-readable metadata for CI and debugging and is not executed by `migrate`.
+
 ## Required sections
 
 Each migration file must define both:
@@ -55,7 +63,7 @@ DBWarden supports three execution classes:
 
 ## Execution model
 
-At runtime, DBWarden builds a plan from file discovery + migration metadata:
+At runtime, DBWarden builds an execution plan from file discovery + migration metadata:
 
 1. read versioned files and filter already-applied versions
 2. include `RA__` files

--- a/docs/reference/configuration-api.md
+++ b/docs/reference/configuration-api.md
@@ -17,6 +17,7 @@ def database_config(
     database_url: str,
     default: bool = False,
     migrations_dir: str | None = None,
+    migration_table: str | None = None,
     model_paths: list[str] | None = None,
     dev_database_type: str | None = None,
     dev_database_url: str | None = None,
@@ -40,6 +41,7 @@ def database_config(
 |----------|------|---------|-------------|
 | `default` | `bool` | `False` | if `True`, this database is used when `--database` is omitted |
 | `migrations_dir` | `str | None` | `None` | custom migration directory path (defaults to `migrations/<database_name>`) |
+| `migration_table` | `str | None` | `None` | custom migration tracking table name (defaults to `_dbwarden_migrations`) |
 | `model_paths` | `list[str] | None` | `None` | list of Python import paths containing SQLAlchemy models for this database |
 | `dev_database_type` | `str | None` | `None` | backend type for local development (used with `--dev`) |
 | `dev_database_url` | `str | None` | `None` | connection URL for local development (used with `--dev`) |
@@ -156,6 +158,32 @@ model_paths=["app.models.api.v1", "app.models.api.v2"]
 
 !!! info "Multi-Database"
     See **[Multi-Database Guide](../configuration/multi-database.md)** for organizing models across databases.
+
+### `migration_table`
+
+Name of the table DBWarden uses to record applied migrations and repeatable migration checksums.
+
+- Defaults to `_dbwarden_migrations`
+- Must be a valid SQL identifier
+- Applies per database entry
+- Only affects migration tracking metadata; lock tables are separate
+
+**Example:**
+
+```python
+database_config(
+    database_name="primary",
+    default=True,
+    database_type="postgresql",
+    database_url="postgresql://localhost/myapp",
+    migration_table="custom_migrations",
+)
+```
+
+Use this when:
+
+- integrating with an existing database that already reserves a migrations table name
+- isolating DBWarden metadata under a project-specific convention
 
 ### `dev_database_type` and `dev_database_url`
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,6 +47,25 @@ class TestConfig:
                 assert config.sqlalchemy_url == "sqlite:///./test.db"
                 assert config.database_type == "sqlite"
                 assert config.migrations_dir == "migrations/primary"
+                assert config.migration_table == "_dbwarden_migrations"
+            finally:
+                os.chdir(old)
+
+    def test_get_config_uses_custom_migration_table(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                _write_settings(
+                    Path("dbwarden.py"),
+                    [
+                        "from dbwarden import database_config",
+                        "",
+                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url='sqlite:///./test.db', migration_table='custom_migrations')",
+                    ],
+                )
+                config = get_config()
+                assert config.migration_table == "custom_migrations"
             finally:
                 os.chdir(old)
 

--- a/tests/test_make_migrations.py
+++ b/tests/test_make_migrations.py
@@ -1,8 +1,11 @@
 import os
 import tempfile
+import json
+from pathlib import Path
 
-from dbwarden.commands.make_migrations import generate_migration_sql
+from dbwarden.commands.make_migrations import build_migration_plan, generate_migration_sql, make_migrations_cmd
 from dbwarden.engine.model_discovery import ModelColumn, ModelTable
+from dbwarden.engine.migration_name import Change
 
 
 def _write_migration(directory: str, name: str, content: str) -> None:
@@ -78,3 +81,64 @@ DROP TABLE users
         assert "ALTER TABLE users ADD COLUMN email" in upgrade_sql
         assert "CREATE TABLE IF NOT EXISTS users" not in upgrade_sql
         assert "ALTER TABLE users DROP COLUMN email" in rollback_sql
+
+
+def test_build_migration_plan_includes_operations_and_checksum():
+    plan = build_migration_plan(
+        migration_id="primary__0001_add_users_age",
+        changes=[Change(operation="add_column", table="users", target="age")],
+        upgrade_sql="ALTER TABLE users ADD COLUMN age INTEGER",
+    )
+
+    assert plan["migration_id"] == "primary__0001_add_users_age"
+    assert plan["required_flags"] == []
+    assert plan["operations"] == [
+        {
+            "type": "add_column",
+            "table": "users",
+            "column": "age",
+            "severity": "INFO",
+        }
+    ]
+    assert isinstance(plan["checksum"], str)
+    assert plan["checksum"]
+
+
+def test_make_migrations_writes_plan_file_next_to_sql():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        old_cwd = os.getcwd()
+        os.chdir(tmpdir)
+        try:
+            Path("dbwarden.py").write_text(
+                "from dbwarden import database_config\n\n"
+                "database_config(database_name='primary', default=True, database_type='sqlite', database_url='sqlite:///./app.db', model_paths=['models'])\n",
+                encoding="utf-8",
+            )
+            Path("migrations/primary").mkdir(parents=True)
+            Path("models").mkdir(parents=True)
+            Path("models/user.py").write_text(
+                "from sqlalchemy import Column, Integer, String\n"
+                "from sqlalchemy.orm import declarative_base\n\n"
+                "Base = declarative_base()\n\n"
+                "class User(Base):\n"
+                "    __tablename__ = 'users'\n"
+                "    id = Column(Integer, primary_key=True)\n"
+                "    email = Column(String(255), nullable=False, unique=True)\n",
+                encoding="utf-8",
+            )
+
+            make_migrations_cmd(database="primary")
+
+            sql_files = sorted(Path("migrations/primary").glob("*.sql"))
+            plan_files = sorted(Path("migrations/primary").glob("*.plan.json"))
+
+            assert len(sql_files) == 1
+            assert len(plan_files) == 1
+            assert plan_files[0].name == sql_files[0].with_suffix(".plan.json").name
+
+            plan = json.loads(plan_files[0].read_text(encoding="utf-8"))
+            assert plan["migration_id"] == sql_files[0].stem
+            assert plan["operations"]
+            assert plan["checksum"]
+        finally:
+            os.chdir(old_cwd)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -14,3 +14,14 @@ def test_sqlite_migration_table_query_uses_filename(monkeypatch):
     sql = queries.get_query(QueryMethod.CREATE_MIGRATIONS_TABLE)
     assert "filename" in sql
     assert "AUTOINCREMENT" not in sql
+
+
+def test_query_uses_custom_migration_table(monkeypatch):
+    class FakeConfig:
+        migration_table = "custom_migrations"
+
+    monkeypatch.setattr(queries, "_get_backend_name", lambda db_name=None: "sqlite")
+    monkeypatch.setattr(queries, "get_database", lambda db_name=None: FakeConfig())
+    sql = queries.get_query(QueryMethod.GET_MIGRATED_VERSIONS)
+    assert "custom_migrations" in sql
+    assert "dbwarden_migrations" not in sql


### PR DESCRIPTION
- add make-migrations --plan support and always write companion .plan.json files for generated migrations
- include machine-readable operation metadata and checksums in migration plans
- add per-database migration_table config with _dbwarden_migrations as the default
- route migration metadata queries through the configured migration table name
- add targeted tests for plan generation and configurable migration tables