### PR TITLE
Feat: add ClickHouse table option rendering

### DIFF
--- a/dbwarden/engine/model_discovery.py
+++ b/dbwarden/engine/model_discovery.py
@@ -112,6 +112,7 @@ class ModelColumn:
         unique: bool,
         default: Optional[str],
         foreign_key: Optional[str],
+        codec: Optional[str] = None,
     ):
         self.name = name
         self.type = type
@@ -120,6 +121,7 @@ class ModelColumn:
         self.unique = unique
         self.default = default
         self.foreign_key = foreign_key
+        self.codec = codec
 
     def to_dict(self) -> dict:
         return {
@@ -130,6 +132,7 @@ class ModelColumn:
             "unique": self.unique,
             "default": self.default,
             "foreign_key": self.foreign_key,
+            "codec": self.codec,
         }
 
 
@@ -140,15 +143,136 @@ class ModelTable:
         self,
         name: str,
         columns: List[ModelColumn],
+        clickhouse_options: Optional[dict] = None,
     ):
         self.name = name
         self.columns = columns
+        self.clickhouse_options = clickhouse_options or {}
 
     def to_dict(self) -> dict:
         return {
             "name": self.name,
             "columns": [col.to_dict() for col in self.columns],
+            "clickhouse_options": self.clickhouse_options,
         }
+
+
+def _extract_table_args_dict(model_class: type) -> dict:
+    table_args = getattr(model_class, "__table_args__", None)
+    if isinstance(table_args, dict):
+        return table_args
+    if isinstance(table_args, tuple) and table_args and isinstance(table_args[-1], dict):
+        return table_args[-1]
+    return {}
+
+
+def _clickhouse_options_for_model(model_class: type) -> dict:
+    table_args = _extract_table_args_dict(model_class)
+    keys = {
+        "clickhouse_engine",
+        "clickhouse_order_by",
+        "clickhouse_primary_key",
+        "clickhouse_partition_by",
+        "clickhouse_sample_by",
+        "clickhouse_ttl",
+    }
+    options = {key: table_args[key] for key in keys if key in table_args}
+    _validate_clickhouse_options(options)
+    return options
+
+
+def _validate_clickhouse_options(options: dict) -> None:
+    order_by = options.get("clickhouse_order_by")
+    primary_key = options.get("clickhouse_primary_key")
+
+    if order_by is not None and not isinstance(order_by, (str, list, tuple)):
+        raise ValueError("clickhouse_order_by must be a string or list/tuple of strings")
+
+    if isinstance(order_by, (list, tuple)):
+        if not order_by:
+            raise ValueError("clickhouse_order_by cannot be empty")
+        if not all(isinstance(item, str) and item.strip() for item in order_by):
+            raise ValueError("clickhouse_order_by entries must be non-empty strings")
+
+    if primary_key is not None and not isinstance(primary_key, (str, list, tuple)):
+        raise ValueError(
+            "clickhouse_primary_key must be a string or list/tuple of strings"
+        )
+
+    if isinstance(primary_key, (list, tuple)):
+        if not primary_key:
+            raise ValueError("clickhouse_primary_key cannot be empty")
+        if not all(isinstance(item, str) and item.strip() for item in primary_key):
+            raise ValueError("clickhouse_primary_key entries must be non-empty strings")
+
+    if isinstance(order_by, (list, tuple)) and primary_key:
+        normalized = [item.strip() for item in order_by]
+        if isinstance(primary_key, str):
+            primary_key_parts = [primary_key]
+        else:
+            primary_key_parts = [item.strip() for item in primary_key]
+
+        if normalized[: len(primary_key_parts)] != primary_key_parts:
+            raise ValueError(
+                "clickhouse_primary_key must be a prefix of clickhouse_order_by"
+            )
+
+    ttl = options.get("clickhouse_ttl")
+    if ttl is not None:
+        if not isinstance(ttl, (list, tuple)):
+            raise ValueError("clickhouse_ttl must be a list/tuple of expressions")
+        if not all(isinstance(item, str) and item.strip() for item in ttl):
+            raise ValueError("clickhouse_ttl entries must be non-empty strings")
+
+
+def _format_clickhouse_expression(value: str | list[str] | tuple[str, ...]) -> str:
+    if isinstance(value, str):
+        return value
+    return "(" + ", ".join(value) + ")"
+
+
+def _format_clickhouse_engine(value: str | tuple | list) -> str:
+    if isinstance(value, str):
+        return f"{value}()"
+    if isinstance(value, (tuple, list)) and value:
+        engine_name = value[0]
+        if not isinstance(engine_name, str) or not engine_name.strip():
+            raise ValueError("clickhouse_engine must start with a non-empty engine name")
+        args = ", ".join(str(item) for item in value[1:])
+        return f"{engine_name}({args})"
+    raise ValueError("clickhouse_engine must be a string or tuple/list")
+
+
+def _render_clickhouse_table_suffix(table: ModelTable) -> str:
+    options = table.clickhouse_options
+    if not options:
+        return " ENGINE = MergeTree()"
+
+    parts: list[str] = []
+    engine = options.get("clickhouse_engine", "MergeTree")
+    parts.append(f"ENGINE = {_format_clickhouse_engine(engine)}")
+
+    order_by = options.get("clickhouse_order_by")
+    if order_by is not None:
+        parts.append(f"ORDER BY {_format_clickhouse_expression(order_by)}")
+
+    primary_key = options.get("clickhouse_primary_key")
+    if primary_key:
+        parts.append(f"PRIMARY KEY {_format_clickhouse_expression(primary_key)}")
+
+    partition_by = options.get("clickhouse_partition_by")
+    if partition_by:
+        parts.append(f"PARTITION BY {partition_by}")
+
+    sample_by = options.get("clickhouse_sample_by")
+    if sample_by:
+        parts.append(f"SAMPLE BY {sample_by}")
+
+    ttl = options.get("clickhouse_ttl")
+    if ttl:
+        parts.append("TTL " + ", ".join(ttl))
+
+    return "\n" + "\n".join(parts)
 
 
 def load_model_from_path(filepath: str) -> Optional[ModuleType]:
@@ -355,7 +479,15 @@ def extract_table_from_model(
             if col:
                 columns.append(col)
 
-        return ModelTable(name=table_name, columns=columns)
+        clickhouse_options = {}
+        if _get_backend_name(db_name) == "clickhouse":
+            clickhouse_options = _clickhouse_options_for_model(model_class)
+
+        return ModelTable(
+            name=table_name,
+            columns=columns,
+            clickhouse_options=clickhouse_options,
+        )
     except Exception:
         return None
 
@@ -374,6 +506,10 @@ def extract_column_info(column, db_name: str | None = None) -> Optional[ModelCol
     try:
         name = column.name
         type_str = str(column.type)
+        if _get_backend_name(db_name) == "clickhouse":
+            clickhouse_type_override = column.info.get("clickhouse_type")
+            if isinstance(clickhouse_type_override, str) and clickhouse_type_override.strip():
+                type_str = clickhouse_type_override.strip()
         nullable = column.nullable
         primary_key = column.primary_key
         unique = column.unique
@@ -453,6 +589,12 @@ def extract_column_info(column, db_name: str | None = None) -> Optional[ModelCol
             else:
                 foreign_key = colspec
 
+        codec = None
+        if _get_backend_name(db_name) == "clickhouse":
+            clickhouse_codec = column.info.get("clickhouse_codec")
+            if isinstance(clickhouse_codec, str) and clickhouse_codec.strip():
+                codec = clickhouse_codec.strip()
+
         return ModelColumn(
             name=name,
             type=type_str,
@@ -461,6 +603,7 @@ def extract_column_info(column, db_name: str | None = None) -> Optional[ModelCol
             unique=unique,
             default=default,
             foreign_key=foreign_key,
+            codec=codec,
         )
     except Exception:
         return None
@@ -557,11 +700,15 @@ def generate_create_table_sql(table: ModelTable, db_name: str | None = None) -> 
             col_def += f" DEFAULT {col.default}"
         if col.foreign_key:
             col_def += f" REFERENCES {col.foreign_key}"
+        if backend == "clickhouse" and col.codec:
+            col_def += f" CODEC({col.codec})"
         column_defs.append(col_def)
 
     columns_sql = ",\n".join(column_defs)
-
-    return f"CREATE TABLE IF NOT EXISTS {table.name} (\n{columns_sql}\n)"
+    sql = f"CREATE TABLE IF NOT EXISTS {table.name} (\n{columns_sql}\n)"
+    if backend == "clickhouse":
+        sql += _render_clickhouse_table_suffix(table)
+    return sql
 
 
 def generate_drop_table_sql(table_name: str) -> str:

--- a/docs/databases.md
+++ b/docs/databases.md
@@ -124,7 +124,10 @@ SQLite:
 ClickHouse:
 
 - Optimized for analytics workloads
-- Use manual SQL for engine/partition/order specifics when needed
+- DBWarden can now render engine and table settings from model metadata
+- Use `__table_args__` for `clickhouse_engine`, `clickhouse_order_by`, `clickhouse_primary_key`, `clickhouse_partition_by`, `clickhouse_sample_by`, and `clickhouse_ttl`
+- Use column `info` for `clickhouse_type` and `clickhouse_codec` hints
+- See [SQLAlchemy Models](models.md) for model examples
 
 ## Recommended Verification Workflow
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -20,3 +20,70 @@ Related docs:
 
 - [Configuration](configuration.md)
 - [Your First Migration](tutorial/your-first-migration.md)
+
+## ClickHouse Model Metadata
+
+When `database_type="clickhouse"`, DBWarden can read ClickHouse-specific options from `__table_args__` and column `info` metadata.
+
+### Table options
+
+Supported keys:
+
+- `clickhouse_engine`
+- `clickhouse_order_by`
+- `clickhouse_primary_key`
+- `clickhouse_partition_by`
+- `clickhouse_sample_by`
+- `clickhouse_ttl`
+
+Example:
+
+```python
+class Event(Base):
+    __tablename__ = "events"
+    __table_args__ = {
+        "clickhouse_engine": ("ReplacingMergeTree", "version_column"),
+        "clickhouse_order_by": ["region", "event_time"],
+        "clickhouse_primary_key": "region",
+        "clickhouse_partition_by": "toYYYYMM(event_time)",
+        "clickhouse_sample_by": "intHash64(user_id)",
+        "clickhouse_ttl": [
+            "event_time + INTERVAL 1 MONTH DELETE",
+            "event_time + INTERVAL 1 YEAR TO DISK 'cold'",
+        ],
+    }
+```
+
+Notes:
+
+- `clickhouse_engine="SummingMergeTree"` renders as `ENGINE = SummingMergeTree()`
+- tuple/list engine values render positional arguments, for example `("ReplacingMergeTree", "version_column")`
+- `clickhouse_primary_key` may be a string or ordered list/tuple, but it must be a prefix of `clickhouse_order_by`
+- if no ClickHouse engine is configured, DBWarden currently falls back to `ENGINE = MergeTree()`
+
+### Column hints
+
+Use column `info` to attach ClickHouse-specific metadata:
+
+```python
+from sqlalchemy import Column, String
+
+payload = Column(
+    String,
+    info={
+        "clickhouse_type": "LowCardinality(String)",
+        "clickhouse_codec": "ZSTD(3)",
+    },
+)
+```
+
+Supported column hints:
+
+- `clickhouse_type`: explicit rendered type string
+- `clickhouse_codec`: rendered as `CODEC(...)`
+
+This is useful when:
+
+- you are using a custom SQLAlchemy type that should render as a ClickHouse-specific SQL type
+- you want explicit control over wrapper types like `LowCardinality(...)`, `Array(...)`, `Map(...)`, or `Tuple(...)`
+- you need per-column compression settings

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -3,10 +3,12 @@ import tempfile
 import os
 from pathlib import Path
 
+import dbwarden.engine.model_discovery as model_discovery
 from dbwarden.engine.model_discovery import (
     load_model_from_path,
     discover_models_in_directory,
     extract_column_info,
+    extract_table_from_model,
     generate_create_table_sql,
     generate_drop_table_sql,
     ModelColumn,
@@ -129,6 +131,21 @@ class TestModelColumn:
         assert col_dict["type"] == "VARCHAR(255)"
         assert col_dict["unique"] == True
 
+    def test_model_column_to_dict_includes_codec(self):
+        col = ModelColumn(
+            name="data",
+            type="String",
+            nullable=False,
+            primary_key=False,
+            unique=False,
+            default=None,
+            foreign_key=None,
+            codec="ZSTD(3)",
+        )
+
+        col_dict = col.to_dict()
+        assert col_dict["codec"] == "ZSTD(3)"
+
 
 class TestModelTable:
     """Tests for ModelTable class."""
@@ -156,6 +173,20 @@ class TestModelTable:
 
         assert table_dict["name"] == "users"
         assert len(table_dict["columns"]) == 1
+
+    def test_model_table_to_dict_includes_clickhouse_options(self):
+        columns = [
+            ModelColumn("id", "UInt64", False, True, False, None, None),
+        ]
+
+        table = ModelTable(
+            name="events",
+            columns=columns,
+            clickhouse_options={"clickhouse_engine": "MergeTree"},
+        )
+
+        table_dict = table.to_dict()
+        assert table_dict["clickhouse_options"]["clickhouse_engine"] == "MergeTree"
 
 
 class TestSQLGeneration:
@@ -193,6 +224,70 @@ class TestSQLGeneration:
         sql = generate_create_table_sql(table)
 
         assert "user_id INTEGER NOT NULL REFERENCES users(id)" in sql
+
+    def test_generate_clickhouse_create_table_sql_with_options(self, monkeypatch):
+        monkeypatch.setattr(model_discovery, "_get_backend_name", lambda db_name=None: "clickhouse")
+
+        columns = [
+            ModelColumn("region", "String", False, True, False, None, None),
+            ModelColumn("event_time", "DateTime", False, False, False, None, None),
+        ]
+
+        table = ModelTable(
+            name="events",
+            columns=columns,
+            clickhouse_options={
+                "clickhouse_engine": ("ReplacingMergeTree", "version_column"),
+                "clickhouse_order_by": ["region", "event_time"],
+                "clickhouse_primary_key": "region",
+                "clickhouse_partition_by": "toYYYYMM(event_time)",
+                "clickhouse_sample_by": "intHash64(region)",
+                "clickhouse_ttl": ["event_time + INTERVAL 1 MONTH DELETE"],
+            },
+        )
+
+        sql = generate_create_table_sql(table)
+
+        assert "ENGINE = ReplacingMergeTree(version_column)" in sql
+        assert "ORDER BY (region, event_time)" in sql
+        assert "PRIMARY KEY region" in sql
+        assert "PARTITION BY toYYYYMM(event_time)" in sql
+        assert "SAMPLE BY intHash64(region)" in sql
+        assert "TTL event_time + INTERVAL 1 MONTH DELETE" in sql
+
+    def test_generate_clickhouse_create_table_sql_with_composite_primary_key(self, monkeypatch):
+        monkeypatch.setattr(model_discovery, "_get_backend_name", lambda db_name=None: "clickhouse")
+
+        columns = [
+            ModelColumn("region", "String", False, False, False, None, None),
+            ModelColumn("event_time", "DateTime", False, False, False, None, None),
+        ]
+
+        table = ModelTable(
+            name="events",
+            columns=columns,
+            clickhouse_options={
+                "clickhouse_order_by": ["region", "event_time"],
+                "clickhouse_primary_key": ["region", "event_time"],
+            },
+        )
+
+        sql = generate_create_table_sql(table)
+
+        assert "PRIMARY KEY (region, event_time)" in sql
+
+    def test_generate_clickhouse_create_table_sql_with_codec(self, monkeypatch):
+        monkeypatch.setattr(model_discovery, "_get_backend_name", lambda db_name=None: "clickhouse")
+
+        columns = [
+            ModelColumn("data", "String", False, False, False, None, None, codec="ZSTD(3)"),
+        ]
+
+        table = ModelTable(name="events", columns=columns)
+        sql = generate_create_table_sql(table)
+
+        assert "data String NOT NULL CODEC(ZSTD(3))" in sql
+        assert "ENGINE = MergeTree()" in sql
 
 
 class TestColumnExtraction:
@@ -257,3 +352,85 @@ class TestColumnExtraction:
 
         assert col is not None
         assert col.type == "TEXT"
+
+    def test_extract_column_uses_clickhouse_type_and_codec_hints(self, monkeypatch):
+        from sqlalchemy import Column, String
+
+        monkeypatch.setattr(model_discovery, "_get_backend_name", lambda db_name=None: "clickhouse")
+
+        col_obj = Column(
+            "payload",
+            String,
+            info={
+                "clickhouse_type": "LowCardinality(String)",
+                "clickhouse_codec": "ZSTD(3)",
+            },
+        )
+
+        col = extract_column_info(col_obj)
+
+        assert col is not None
+        assert col.type == "LowCardinality(String)"
+        assert col.codec == "ZSTD(3)"
+
+    def test_extract_column_preserves_clickhouse_user_defined_type(self, monkeypatch):
+        from sqlalchemy import Column
+        from sqlalchemy.types import UserDefinedType
+
+        monkeypatch.setattr(model_discovery, "_get_backend_name", lambda db_name=None: "clickhouse")
+
+        class LowCardinalityString(UserDefinedType):
+            def get_col_spec(self, **kw):
+                return "LowCardinality(String)"
+
+        col_obj = Column("payload", LowCardinalityString())
+
+        col = extract_column_info(col_obj)
+
+        assert col is not None
+        assert col.type == "LowCardinality(String)"
+
+    def test_extract_table_from_model_uses_clickhouse_table_args(self, monkeypatch):
+        from sqlalchemy import Column, MetaData, String, Table
+
+        monkeypatch.setattr(model_discovery, "_get_backend_name", lambda db_name=None: "clickhouse")
+
+        class Event:
+            __tablename__ = "events"
+            __table_args__ = {
+                "clickhouse_engine": "SummingMergeTree",
+                "clickhouse_order_by": ["region"],
+            }
+            __table__ = Table(
+                "events",
+                MetaData(),
+                Column("region", String, primary_key=True),
+            )
+
+        table = extract_table_from_model(Event, db_name="primary")
+
+        assert table is not None
+        assert table.clickhouse_options["clickhouse_engine"] == "SummingMergeTree"
+        assert table.clickhouse_options["clickhouse_order_by"] == ["region"]
+
+    def test_extract_table_from_model_rejects_invalid_clickhouse_primary_key_prefix(self, monkeypatch):
+        from sqlalchemy import Column, MetaData, String, Table
+
+        monkeypatch.setattr(model_discovery, "_get_backend_name", lambda db_name=None: "clickhouse")
+
+        class Event:
+            __tablename__ = "events"
+            __table_args__ = {
+                "clickhouse_order_by": ["region", "event_time"],
+                "clickhouse_primary_key": ["event_time"],
+            }
+            __table__ = Table(
+                "events",
+                MetaData(),
+                Column("region", String),
+                Column("event_time", String),
+            )
+
+        table = extract_table_from_model(Event, db_name="primary")
+
+        assert table is None


### PR DESCRIPTION
- add ClickHouse-specific table metadata support in model extraction and SQL generation
- render clickhouse_engine, clickhouse_order_by, clickhouse_primary_key, clickhouse_partition_by, clickhouse_sample_by, and clickhouse_ttl
- support per-column clickhouse_type and clickhouse_codec hints
- validate ClickHouse primary-key prefix rules
- add focused tests for ClickHouse table rendering and metadata extraction
- document ClickHouse model metadata usage in the docs