### PR TITLE
fix: avoid creating dbwarden.py.bak on first init

### DIFF
--- a/dbwarden/commands/init.py
+++ b/dbwarden/commands/init.py
@@ -41,10 +41,9 @@ def _atomic_write(path: Path, content: str) -> None:
 
 def _ensure_settings_file(settings_path: Path, db_name: str) -> None:
     settings_path.parent.mkdir(parents=True, exist_ok=True)
-    if not settings_path.exists():
-        _atomic_write(settings_path, "")
-
-    content = settings_path.read_text(encoding="utf-8")
+    content = ""
+    if settings_path.exists():
+        content = settings_path.read_text(encoding="utf-8")
     lines = content.splitlines()
 
     import_line = "from dbwarden import database_config"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -36,6 +36,17 @@ class TestInitCommand:
             finally:
                 os.chdir(old_cwd)
 
+    def test_init_does_not_create_backup_on_first_run(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                init_cmd()
+                assert Path(tmpdir, "dbwarden.py").exists()
+                assert not Path(tmpdir, "dbwarden.py.bak").exists()
+            finally:
+                os.chdir(old_cwd)
+
     def test_init_does_not_duplicate_scaffold(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             old_cwd = os.getcwd()


### PR DESCRIPTION
- stop dbwarden init from creating a .bak file when dbwarden.py is being created for the first time
- keep backup behavior for real updates to an existing config file
- add a regression test covering first-run init behavior