### PR TITLE
ClickHouse materialized views, projections, and safety analysis

### DIFF
--- a/dbwarden/cli/main.py
+++ b/dbwarden/cli/main.py
@@ -4,6 +4,7 @@ from dbwarden.cli.validators import validate_directory
 from dbwarden.config import set_dev_mode, set_strict_translation
 from dbwarden.commands import (
     handle_check_db,
+    handle_check,
     handle_config,
     handle_database_add,
     handle_database_list,
@@ -329,6 +330,25 @@ def status(
     """Show migration status (applied and pending)."""
     validate_directory()
     handle_status(database=database, all_databases=all_databases)
+
+
+@app.command()
+def check(
+    output: str = typer.Option(
+        "txt", "--out", "-o", help="Output format (json, txt)"
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Allow warning-level changes to pass",
+    ),
+    database: str | None = typer.Option(
+        None, "--database", "-d", help="Target database name"
+    ),
+):
+    """Run the schema safety analyzer."""
+    validate_directory()
+    handle_check(output_format=output, database=database, force=force)
 
 
 @app.command()

--- a/dbwarden/commands/__init__.py
+++ b/dbwarden/commands/__init__.py
@@ -1,3 +1,4 @@
+from dbwarden.commands.check import check_cmd
 from dbwarden.commands.check_db import check_db_cmd
 from dbwarden.commands.extra import diff_cmd, lock_status_cmd, squash_cmd, unlock_cmd
 from dbwarden.commands.history import history_cmd
@@ -127,6 +128,15 @@ def handle_status(database: str | None = None, all_databases: bool = False) -> N
 def handle_check_db(output_format: str, database: str | None = None) -> None:
     """Handle check-db command."""
     check_db_cmd(output_format=output_format, database=database)
+
+
+def handle_check(
+    output_format: str,
+    database: str | None = None,
+    force: bool = False,
+) -> None:
+    """Handle safety check command."""
+    check_cmd(output_format=output_format, database=database, force=force)
 
 
 def handle_diff(diff_type: str, verbose: bool, database: str | None = None) -> None:

--- a/dbwarden/commands/check.py
+++ b/dbwarden/commands/check.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from rich.table import Table
+
+from dbwarden.engine.safety import issues_to_json, load_issues
+from dbwarden.output import console
+
+
+def check_cmd(
+    output_format: str = "txt",
+    database: str | None = None,
+    force: bool = False,
+) -> None:
+    issues = load_issues(database=database)
+
+    if output_format == "json":
+        console.print(issues_to_json(issues), markup=False, highlight=False)
+    elif output_format == "txt":
+        _print_issues_table(issues, database=database)
+    else:
+        raise ValueError(f"Unknown output format: {output_format}")
+
+    errors = [issue for issue in issues if issue.severity == "ERROR"]
+    warnings = [issue for issue in issues if issue.severity == "WARNING"]
+    if errors:
+        raise RuntimeError("Safety check failed: blocking changes detected.")
+    if warnings and not force:
+        raise RuntimeError("Safety check failed: warning-level changes require --force.")
+
+
+def _print_issues_table(issues, database: str | None = None) -> None:
+    db_label = database or "default"
+    table = Table(
+        title=f"Safety Check - {db_label}",
+        show_header=True,
+        header_style="bold magenta",
+    )
+    table.add_column("Severity", style="cyan")
+    table.add_column("Change", style="white")
+    table.add_column("Table", style="green")
+    table.add_column("Column", style="yellow")
+    table.add_column("Message", style="white")
+    table.add_column("Required Flag", style="magenta")
+
+    for issue in issues:
+        table.add_row(
+            issue.severity,
+            issue.change_type,
+            issue.table_name,
+            issue.column_name or "",
+            issue.message,
+            issue.required_flag or "",
+        )
+
+    console.print(table)
+    if not issues:
+        console.print("No schema changes detected.", style="green")

--- a/dbwarden/commands/make_migrations.py
+++ b/dbwarden/commands/make_migrations.py
@@ -12,7 +12,7 @@ from dbwarden.engine.model_discovery import (
     get_all_model_tables,
     auto_discover_model_paths,
     generate_create_table_sql,
-    generate_drop_table_sql,
+    generate_drop_object_sql,
     generate_add_column_sql,
     extract_tables_from_migrations,
     extract_tables_from_database,
@@ -252,7 +252,7 @@ def generate_migration_sql(
         if not existing_columns:
             create_sql = generate_create_table_sql(table, db_name)
             upgrade_parts.append(create_sql)
-            rollback_parts.append(generate_drop_table_sql(table.name))
+            rollback_parts.append(generate_drop_object_sql(table))
             changes.append(Change(operation="create_table", table=table.name))
         else:
             for column in table.columns:

--- a/dbwarden/engine/model_discovery.py
+++ b/dbwarden/engine/model_discovery.py
@@ -144,16 +144,19 @@ class ModelTable:
         name: str,
         columns: List[ModelColumn],
         clickhouse_options: Optional[dict] = None,
+        object_type: str = "table",
     ):
         self.name = name
         self.columns = columns
         self.clickhouse_options = clickhouse_options or {}
+        self.object_type = object_type
 
     def to_dict(self) -> dict:
         return {
             "name": self.name,
             "columns": [col.to_dict() for col in self.columns],
             "clickhouse_options": self.clickhouse_options,
+            "object_type": self.object_type,
         }
 
 
@@ -175,6 +178,12 @@ def _clickhouse_options_for_model(model_class: type) -> dict:
         "clickhouse_partition_by",
         "clickhouse_sample_by",
         "clickhouse_ttl",
+        "clickhouse_mv",
+        "clickhouse_mv_query",
+        "clickhouse_mv_engine",
+        "clickhouse_mv_order_by",
+        "clickhouse_mv_populate",
+        "clickhouse_projections",
     }
     options = {key: table_args[key] for key in keys if key in table_args}
     _validate_clickhouse_options(options)
@@ -184,6 +193,8 @@ def _clickhouse_options_for_model(model_class: type) -> dict:
 def _validate_clickhouse_options(options: dict) -> None:
     order_by = options.get("clickhouse_order_by")
     primary_key = options.get("clickhouse_primary_key")
+    mv_enabled = bool(options.get("clickhouse_mv"))
+    projections = options.get("clickhouse_projections")
 
     if order_by is not None and not isinstance(order_by, (str, list, tuple)):
         raise ValueError("clickhouse_order_by must be a string or list/tuple of strings")
@@ -223,6 +234,49 @@ def _validate_clickhouse_options(options: dict) -> None:
             raise ValueError("clickhouse_ttl must be a list/tuple of expressions")
         if not all(isinstance(item, str) and item.strip() for item in ttl):
             raise ValueError("clickhouse_ttl entries must be non-empty strings")
+
+    if mv_enabled and not options.get("clickhouse_mv_query"):
+        raise ValueError("clickhouse_mv_query is required when clickhouse_mv=True")
+
+    if options.get("clickhouse_mv_query") and not isinstance(
+        options.get("clickhouse_mv_query"), str
+    ):
+        raise ValueError("clickhouse_mv_query must be a string")
+
+    if "clickhouse_mv_populate" in options and not isinstance(
+        options.get("clickhouse_mv_populate"), bool
+    ):
+        raise ValueError("clickhouse_mv_populate must be a boolean")
+
+    mv_order_by = options.get("clickhouse_mv_order_by")
+    if mv_order_by is not None and not isinstance(mv_order_by, (str, list, tuple)):
+        raise ValueError("clickhouse_mv_order_by must be a string or list/tuple of strings")
+
+    if projections is not None:
+        if not isinstance(projections, list):
+            raise ValueError("clickhouse_projections must be a list")
+        for projection in projections:
+            if not isinstance(projection, dict):
+                raise ValueError("clickhouse_projections entries must be objects")
+            if not projection.get("name") or not projection.get("query"):
+                raise ValueError("clickhouse_projections entries require name and query")
+
+
+def _object_type_for_clickhouse_options(options: dict) -> str:
+    if options.get("clickhouse_mv"):
+        return "materialized_view"
+    return "table"
+
+
+def _render_clickhouse_projection(projection: dict) -> str:
+    projection_name = projection["name"]
+    projection_query = projection["query"]
+    return f"PROJECTION {projection_name} ({projection_query})"
+
+
+def _render_clickhouse_projections(table: ModelTable) -> list[str]:
+    projections = table.clickhouse_options.get("clickhouse_projections") or []
+    return [_render_clickhouse_projection(projection) for projection in projections]
 
 
 def _format_clickhouse_expression(value: str | list[str] | tuple[str, ...]) -> str:
@@ -480,13 +534,16 @@ def extract_table_from_model(
                 columns.append(col)
 
         clickhouse_options = {}
+        object_type = "table"
         if _get_backend_name(db_name) == "clickhouse":
             clickhouse_options = _clickhouse_options_for_model(model_class)
+            object_type = _object_type_for_clickhouse_options(clickhouse_options)
 
         return ModelTable(
             name=table_name,
             columns=columns,
             clickhouse_options=clickhouse_options,
+            object_type=object_type,
         )
     except Exception:
         return None
@@ -704,17 +761,67 @@ def generate_create_table_sql(table: ModelTable, db_name: str | None = None) -> 
             col_def += f" CODEC({col.codec})"
         column_defs.append(col_def)
 
-    columns_sql = ",\n".join(column_defs)
-    sql = f"CREATE TABLE IF NOT EXISTS {table.name} (\n{columns_sql}\n)"
     if backend == "clickhouse":
-        sql += _render_clickhouse_table_suffix(table)
+        column_defs.extend(f"    {projection_sql}" for projection_sql in _render_clickhouse_projections(table))
+
+    columns_sql = ",\n".join(column_defs)
+    if backend == "clickhouse" and table.object_type == "materialized_view":
+        sql = _generate_clickhouse_materialized_view_sql(table, columns_sql)
+    else:
+        sql = f"CREATE TABLE IF NOT EXISTS {table.name} (\n{columns_sql}\n)"
+    if backend == "clickhouse":
+        if table.object_type == "table":
+            sql += _render_clickhouse_table_suffix(table)
     return sql
+
+
+def _generate_clickhouse_materialized_view_sql(
+    table: ModelTable,
+    columns_sql: str,
+) -> str:
+    options = table.clickhouse_options
+    parts = [f"CREATE MATERIALIZED VIEW IF NOT EXISTS {table.name} (\n{columns_sql}\n)"]
+    if options.get("clickhouse_mv_populate"):
+        parts[0] += " POPULATE"
+
+    engine = options.get("clickhouse_mv_engine") or options.get("clickhouse_engine") or "MergeTree"
+    parts.append(f"ENGINE = {_format_clickhouse_engine(engine)}")
+
+    order_by = options.get("clickhouse_mv_order_by") or options.get("clickhouse_order_by")
+    if order_by is not None:
+        parts.append(f"ORDER BY {_format_clickhouse_expression(order_by)}")
+
+    primary_key = options.get("clickhouse_primary_key")
+    if primary_key:
+        parts.append(f"PRIMARY KEY {_format_clickhouse_expression(primary_key)}")
+
+    partition_by = options.get("clickhouse_partition_by")
+    if partition_by:
+        parts.append(f"PARTITION BY {partition_by}")
+
+    sample_by = options.get("clickhouse_sample_by")
+    if sample_by:
+        parts.append(f"SAMPLE BY {sample_by}")
+
+    ttl = options.get("clickhouse_ttl")
+    if ttl:
+        parts.append("TTL " + ", ".join(ttl))
+
+    parts.append(f"AS {options['clickhouse_mv_query']}")
+    return "\n".join(parts)
 
 
 def generate_drop_table_sql(table_name: str) -> str:
     """Generate DROP TABLE SQL."""
     _validate_identifier(table_name, "table_name")
     return f"DROP TABLE {table_name}"
+
+
+def generate_drop_object_sql(table: ModelTable) -> str:
+    _validate_identifier(table.name, "table_name")
+    if table.object_type == "materialized_view":
+        return f"DROP VIEW {table.name}"
+    return generate_drop_table_sql(table.name)
 
 
 def extract_tables_from_database(sqlalchemy_url: str) -> dict[str, set[str]]:

--- a/dbwarden/engine/safety.py
+++ b/dbwarden/engine/safety.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict
+from typing import Any
+
+from sqlalchemy import text
+
+from dbwarden.database.connection import get_db_connection
+from dbwarden.engine.model_discovery import ModelTable, get_all_model_tables
+from dbwarden.models import SafetyIssue
+
+
+def _normalize_option_value(value: Any) -> Any:
+    if isinstance(value, tuple):
+        return list(value)
+    return value
+
+
+def extract_schema_snapshot(database: str | None = None) -> dict[str, dict[str, Any]]:
+    from dbwarden.config import get_database
+
+    config = get_database(database)
+    if config.database_type == "clickhouse":
+        return _extract_clickhouse_schema_snapshot(database)
+    return _extract_generic_schema_snapshot(database)
+
+
+def _extract_generic_schema_snapshot(database: str | None = None) -> dict[str, dict[str, Any]]:
+    from sqlalchemy import inspect
+
+    snapshot: dict[str, dict[str, Any]] = {}
+    with get_db_connection(database) as connection:
+        inspector = inspect(connection)
+        for table_name in inspector.get_table_names():
+            columns = inspector.get_columns(table_name)
+            snapshot[table_name] = {
+                "object_type": "table",
+                "columns": {
+                    col["name"]: {
+                        "type": str(col["type"]),
+                        "nullable": bool(col.get("nullable", True)),
+                        "default": col.get("default"),
+                    }
+                    for col in columns
+                },
+                "clickhouse_options": {},
+            }
+    return snapshot
+
+
+def _extract_clickhouse_schema_snapshot(database: str | None = None) -> dict[str, dict[str, Any]]:
+    snapshot: dict[str, dict[str, Any]] = {}
+    with get_db_connection(database) as connection:
+        rows = connection.execute(
+            text(
+                "SELECT name, engine, sorting_key, primary_key, partition_key, sampling_key, create_table_query "
+                "FROM system.tables WHERE database = currentDatabase()"
+            )
+        ).fetchall()
+        for row in rows:
+            table_name = row.name
+            columns = connection.execute(
+                text(
+                    "SELECT name, type, default_expression FROM system.columns "
+                    "WHERE database = currentDatabase() AND table = :table_name"
+                ),
+                parameters={"table_name": table_name},
+            ).fetchall()
+            create_query = getattr(row, "create_table_query", "") or ""
+            snapshot[table_name] = {
+                "object_type": "materialized_view"
+                if create_query.upper().startswith("CREATE MATERIALIZED VIEW")
+                else "table",
+                "columns": {
+                    col.name: {
+                        "type": col.type,
+                        "nullable": col.type.startswith("Nullable("),
+                        "default": getattr(col, "default_expression", None),
+                    }
+                    for col in columns
+                },
+                "clickhouse_options": {
+                    "clickhouse_engine": getattr(row, "engine", None),
+                    "clickhouse_order_by": _parse_tuple_expression(getattr(row, "sorting_key", None)),
+                    "clickhouse_primary_key": _parse_tuple_expression(getattr(row, "primary_key", None)),
+                    "clickhouse_partition_by": _clean_expression(getattr(row, "partition_key", None)),
+                    "clickhouse_sample_by": _clean_expression(getattr(row, "sampling_key", None)),
+                    "clickhouse_ttl": _parse_ttl_expressions(create_query),
+                    "clickhouse_projections": _parse_projection_names(create_query),
+                    "clickhouse_mv_query": _parse_mv_query(create_query),
+                },
+            }
+    return snapshot
+
+
+def _clean_expression(value: Any) -> str | None:
+    if value is None:
+        return None
+    value_str = str(value).strip()
+    if not value_str:
+        return None
+    return value_str
+
+
+def _parse_tuple_expression(value: Any) -> str | list[str] | None:
+    value_str = _clean_expression(value)
+    if value_str is None:
+        return None
+    if value_str.startswith("tuple(") and value_str.endswith(")"):
+        inner = value_str[6:-1].strip()
+        if not inner:
+            return []
+        return [part.strip() for part in inner.split(",")]
+    return value_str
+
+
+def _parse_ttl_expressions(create_query: str) -> list[str]:
+    ttl_match = re.search(
+        r"\bTTL\s+(.+?)(?:\n(?:SETTINGS|COMMENT|AS|PRIMARY KEY|ORDER BY|PARTITION BY|SAMPLE BY)\b|$)",
+        create_query,
+        re.IGNORECASE | re.DOTALL,
+    )
+    if not ttl_match:
+        return []
+    ttl_body = ttl_match.group(1).strip()
+    return [part.strip() for part in ttl_body.split(",") if part.strip()]
+
+
+def _parse_projection_names(create_query: str) -> list[str]:
+    return re.findall(r"PROJECTION\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(", create_query, re.IGNORECASE)
+
+
+def _parse_mv_query(create_query: str) -> str | None:
+    mv_match = re.search(r"\bAS\s+SELECT\s+.+$", create_query, re.IGNORECASE | re.DOTALL)
+    if not mv_match:
+        return None
+    return mv_match.group(0)[3:].strip()
+
+
+def analyze_schema(
+    model_tables: list[ModelTable],
+    schema_snapshot: dict[str, dict[str, Any]],
+) -> list[SafetyIssue]:
+    issues: list[SafetyIssue] = []
+    model_by_name = {table.name: table for table in model_tables}
+    snapshot_names = set(schema_snapshot.keys())
+    model_names = set(model_by_name.keys())
+
+    for table_name in sorted(model_names - snapshot_names):
+        table = model_by_name[table_name]
+        issues.append(
+            SafetyIssue(
+                severity="INFO",
+                change_type="create_table",
+                table_name=table_name,
+                message=f"Create {table.object_type.replace('_', ' ')} '{table_name}'",
+            )
+        )
+
+    for table_name in sorted(snapshot_names - model_names):
+        issues.append(
+            SafetyIssue(
+                severity="WARNING",
+                change_type="drop_table",
+                table_name=table_name,
+                message=f"Drop table '{table_name}'",
+                required_flag="--force",
+            )
+        )
+
+    for table_name in sorted(snapshot_names & model_names):
+        model_table = model_by_name[table_name]
+        table_snapshot = schema_snapshot[table_name]
+        issues.extend(_analyze_table(table_snapshot, model_table))
+
+    return issues
+
+
+def _analyze_table(table_snapshot: dict[str, Any], model_table: ModelTable) -> list[SafetyIssue]:
+    issues: list[SafetyIssue] = []
+    snapshot_columns = table_snapshot.get("columns", {})
+    model_columns = {column.name: column for column in model_table.columns}
+
+    if table_snapshot.get("object_type", "table") != model_table.object_type:
+        issues.append(
+            SafetyIssue(
+                severity="WARNING",
+                change_type="change_object_type",
+                table_name=model_table.name,
+                message=(
+                    f"Change object type for '{model_table.name}' from "
+                    f"{table_snapshot.get('object_type', 'table')} to {model_table.object_type}"
+                ),
+                required_flag="--force",
+            )
+        )
+
+    for column_name in sorted(model_columns.keys() - snapshot_columns.keys()):
+        column = model_columns[column_name]
+        issues.append(
+            SafetyIssue(
+                severity="INFO",
+                change_type="add_column",
+                table_name=model_table.name,
+                column_name=column_name,
+                message=f"Add column '{column_name}' to '{model_table.name}'",
+            )
+        )
+
+    for column_name in sorted(snapshot_columns.keys() - model_columns.keys()):
+        issues.append(
+            SafetyIssue(
+                severity="WARNING",
+                change_type="drop_column",
+                table_name=model_table.name,
+                column_name=column_name,
+                message=f"Drop column '{column_name}' from '{model_table.name}'",
+                required_flag="--force",
+            )
+        )
+
+    for column_name in sorted(snapshot_columns.keys() & model_columns.keys()):
+        snapshot_column = snapshot_columns[column_name]
+        model_column = model_columns[column_name]
+        if str(snapshot_column.get("type")) != model_column.type:
+            issues.append(
+                SafetyIssue(
+                    severity="WARNING",
+                    change_type="change_column_type",
+                    table_name=model_table.name,
+                    column_name=column_name,
+                    message=(
+                        f"Change type of '{model_table.name}.{column_name}' from "
+                        f"{snapshot_column.get('type')} to {model_column.type}"
+                    ),
+                    required_flag="--force",
+                )
+            )
+
+    issues.extend(_analyze_clickhouse_options(table_snapshot, model_table))
+    return issues
+
+
+def _analyze_clickhouse_options(table_snapshot: dict[str, Any], model_table: ModelTable) -> list[SafetyIssue]:
+    issues: list[SafetyIssue] = []
+    snapshot_options = table_snapshot.get("clickhouse_options", {})
+    model_options = model_table.clickhouse_options
+    if not snapshot_options and not model_options:
+        return issues
+
+    option_rules = {
+        "clickhouse_order_by": ("ERROR", None, "Change ORDER BY for '{table}'"),
+        "clickhouse_partition_by": ("ERROR", None, "Change PARTITION BY for '{table}'"),
+        "clickhouse_ttl": ("WARNING", "--force", "Change TTL for '{table}'"),
+        "clickhouse_engine": ("WARNING", "--force", "Change engine for '{table}'"),
+        "clickhouse_mv_query": ("WARNING", "--force", "Change materialized view query for '{table}'"),
+        "clickhouse_mv_populate": ("WARNING", "--force", "Enable POPULATE for materialized view '{table}'"),
+    }
+
+    for key, (severity, required_flag, template) in option_rules.items():
+        if _normalize_option_value(snapshot_options.get(key)) != _normalize_option_value(model_options.get(key)):
+            if snapshot_options.get(key) is None and model_options.get(key) is None:
+                continue
+            issues.append(
+                SafetyIssue(
+                    severity=severity,
+                    change_type=key,
+                    table_name=model_table.name,
+                    message=template.format(table=model_table.name),
+                    required_flag=required_flag,
+                )
+            )
+
+    snapshot_projections = set(snapshot_options.get("clickhouse_projections") or [])
+    model_projections = {
+        projection["name"]
+        for projection in (model_options.get("clickhouse_projections") or [])
+    }
+
+    for projection_name in sorted(model_projections - snapshot_projections):
+        issues.append(
+            SafetyIssue(
+                severity="INFO",
+                change_type="add_projection",
+                table_name=model_table.name,
+                message=f"Add projection '{projection_name}' to '{model_table.name}'",
+            )
+        )
+
+    for projection_name in sorted(snapshot_projections - model_projections):
+        issues.append(
+            SafetyIssue(
+                severity="WARNING",
+                change_type="drop_projection",
+                table_name=model_table.name,
+                message=f"Drop projection '{projection_name}' from '{model_table.name}'",
+                required_flag="--force",
+            )
+        )
+
+    return issues
+
+
+def load_issues(database: str | None = None) -> list[SafetyIssue]:
+    model_tables = get_all_model_tables(db_name=database)
+    schema_snapshot = extract_schema_snapshot(database=database)
+    return analyze_schema(model_tables, schema_snapshot)
+
+
+def issues_to_json(issues: list[SafetyIssue]) -> str:
+    return json.dumps([asdict(issue) for issue in issues], indent=2)

--- a/dbwarden/models.py
+++ b/dbwarden/models.py
@@ -80,3 +80,14 @@ class SchemaDifference:
     table_name: str
     column_name: str | None = None
     sql: str = ""
+
+
+@dataclass
+class SafetyIssue:
+    severity: str
+    change_type: str
+    table_name: str
+    message: str
+    column_name: str | None = None
+    sql: str = ""
+    required_flag: str | None = None

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -167,6 +167,16 @@ dbwarden check-db --database primary --out json
 
 Output formats: `txt`, `json`, `yaml`
 
+### `check`
+
+```bash
+dbwarden check --database primary
+dbwarden check --database primary --force
+dbwarden check --database primary --out json
+```
+
+Output formats: `txt`, `json`
+
 ### `diff`
 
 ```bash

--- a/docs/commands/check.md
+++ b/docs/commands/check.md
@@ -1,0 +1,42 @@
+# `check`
+
+Analyze schema differences between your SQLAlchemy models and the live database.
+
+## Usage
+
+```bash
+dbwarden check --database primary
+dbwarden check --database primary --force
+dbwarden check --database primary --out json
+```
+
+## Options
+
+- `--database`, `-d` - Target database
+- `--out`, `-o` - Output format: `txt` or `json`
+- `--force` - Allow warning-level changes to pass
+
+## Severity model
+
+- `INFO` - safe changes like adding a projection or adding a new object
+- `WARNING` - risky changes that require `--force`
+- `ERROR` - blocked changes such as partition/order key changes
+
+## Current behavior
+
+For ClickHouse-aware checks, DBWarden classifies changes for:
+
+- added or removed columns
+- type changes
+- engine changes
+- TTL changes
+- `ORDER BY` changes
+- `PARTITION BY` changes
+- materialized view query changes
+- projection additions/removals
+
+## Notes
+
+- warning-level changes exit non-zero unless `--force` is provided
+- error-level changes remain blocking even with `--force`
+- output is based on live database inspection plus current model metadata

--- a/docs/models.md
+++ b/docs/models.md
@@ -35,6 +35,12 @@ Supported keys:
 - `clickhouse_partition_by`
 - `clickhouse_sample_by`
 - `clickhouse_ttl`
+- `clickhouse_mv`
+- `clickhouse_mv_query`
+- `clickhouse_mv_engine`
+- `clickhouse_mv_order_by`
+- `clickhouse_mv_populate`
+- `clickhouse_projections`
 
 Example:
 
@@ -60,6 +66,48 @@ Notes:
 - tuple/list engine values render positional arguments, for example `("ReplacingMergeTree", "version_column")`
 - `clickhouse_primary_key` may be a string or ordered list/tuple, but it must be a prefix of `clickhouse_order_by`
 - if no ClickHouse engine is configured, DBWarden currently falls back to `ENGINE = MergeTree()`
+
+### Materialized views
+
+Use `clickhouse_mv=True` to render a materialized view instead of a regular table:
+
+```python
+class EventRollup(Base):
+    __tablename__ = "event_rollup_mv"
+    __table_args__ = {
+        "clickhouse_mv": True,
+        "clickhouse_mv_query": "SELECT region, count() AS total FROM events GROUP BY region",
+        "clickhouse_mv_engine": "SummingMergeTree",
+        "clickhouse_mv_order_by": ["region"],
+        "clickhouse_mv_populate": False,
+    }
+```
+
+Notes:
+
+- `clickhouse_mv_query` is required when `clickhouse_mv=True`
+- `clickhouse_mv_populate=True` is supported but should be used cautiously
+- materialized view SQL is rendered as `CREATE MATERIALIZED VIEW ... AS SELECT ...`
+
+### Projections
+
+Attach projections directly to a ClickHouse table:
+
+```python
+__table_args__ = {
+    "clickhouse_order_by": ["author", "created_at"],
+    "clickhouse_projections": [
+        {"name": "by_author", "query": "SELECT * ORDER BY author"},
+        {"name": "daily_stats", "query": "SELECT toDate(created_at) AS day, count() GROUP BY day"},
+    ],
+}
+```
+
+Current behavior:
+
+- projection definitions are rendered into generated ClickHouse DDL
+- safety checks classify added projections as `INFO`
+- removed projections are classified as `WARNING`
 
 ### Column hints
 

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -10,6 +10,7 @@ from dbwarden.engine.model_discovery import (
     extract_column_info,
     extract_table_from_model,
     generate_create_table_sql,
+    generate_drop_object_sql,
     generate_drop_table_sql,
     ModelColumn,
     ModelTable,
@@ -289,6 +290,65 @@ class TestSQLGeneration:
         assert "data String NOT NULL CODEC(ZSTD(3))" in sql
         assert "ENGINE = MergeTree()" in sql
 
+    def test_generate_clickhouse_create_table_sql_with_projection(self, monkeypatch):
+        monkeypatch.setattr(model_discovery, "_get_backend_name", lambda db_name=None: "clickhouse")
+
+        columns = [
+            ModelColumn("author", "String", False, False, False, None, None),
+            ModelColumn("created_at", "DateTime", False, False, False, None, None),
+        ]
+
+        table = ModelTable(
+            name="posts",
+            columns=columns,
+            clickhouse_options={
+                "clickhouse_order_by": ["author", "created_at"],
+                "clickhouse_projections": [
+                    {"name": "by_author", "query": "SELECT * ORDER BY author"}
+                ],
+            },
+        )
+
+        sql = generate_create_table_sql(table)
+
+        assert "PROJECTION by_author (SELECT * ORDER BY author)" in sql
+
+    def test_generate_clickhouse_materialized_view_sql(self, monkeypatch):
+        monkeypatch.setattr(model_discovery, "_get_backend_name", lambda db_name=None: "clickhouse")
+
+        columns = [
+            ModelColumn("group_col", "String", False, True, False, None, None),
+            ModelColumn("total", "UInt64", False, False, False, None, None),
+        ]
+
+        table = ModelTable(
+            name="mv_name",
+            columns=columns,
+            clickhouse_options={
+                "clickhouse_mv": True,
+                "clickhouse_mv_query": "SELECT group_col, count() AS total FROM source_table GROUP BY group_col",
+                "clickhouse_mv_engine": "SummingMergeTree",
+                "clickhouse_mv_order_by": ["group_col"],
+            },
+            object_type="materialized_view",
+        )
+
+        sql = generate_create_table_sql(table)
+
+        assert "CREATE MATERIALIZED VIEW IF NOT EXISTS mv_name" in sql
+        assert "ENGINE = SummingMergeTree()" in sql
+        assert "ORDER BY (group_col)" in sql
+        assert "AS SELECT group_col, count() AS total FROM source_table GROUP BY group_col" in sql
+
+    def test_generate_drop_object_sql_for_materialized_view(self):
+        table = ModelTable(
+            name="mv_name",
+            columns=[],
+            object_type="materialized_view",
+        )
+
+        assert generate_drop_object_sql(table) == "DROP VIEW mv_name"
+
 
 class TestColumnExtraction:
     """Tests for column information extraction."""
@@ -412,6 +472,28 @@ class TestColumnExtraction:
         assert table is not None
         assert table.clickhouse_options["clickhouse_engine"] == "SummingMergeTree"
         assert table.clickhouse_options["clickhouse_order_by"] == ["region"]
+
+    def test_extract_table_from_model_sets_materialized_view_object_type(self, monkeypatch):
+        from sqlalchemy import Column, MetaData, String, Table
+
+        monkeypatch.setattr(model_discovery, "_get_backend_name", lambda db_name=None: "clickhouse")
+
+        class EventView:
+            __tablename__ = "mv_name"
+            __table_args__ = {
+                "clickhouse_mv": True,
+                "clickhouse_mv_query": "SELECT region FROM source_table",
+            }
+            __table__ = Table(
+                "mv_name",
+                MetaData(),
+                Column("region", String, primary_key=True),
+            )
+
+        table = extract_table_from_model(EventView, db_name="primary")
+
+        assert table is not None
+        assert table.object_type == "materialized_view"
 
     def test_extract_table_from_model_rejects_invalid_clickhouse_primary_key_prefix(self, monkeypatch):
         from sqlalchemy import Column, MetaData, String, Table

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,0 +1,143 @@
+from dbwarden.commands.check import check_cmd
+from dbwarden.engine.model_discovery import ModelColumn, ModelTable
+from dbwarden.engine.safety import analyze_schema
+
+
+def test_analyze_schema_add_projection_is_info():
+    model_tables = [
+        ModelTable(
+            name="posts",
+            columns=[ModelColumn("author", "String", False, False, False, None, None)],
+            clickhouse_options={
+                "clickhouse_projections": [
+                    {"name": "by_author", "query": "SELECT * ORDER BY author"}
+                ]
+            },
+        )
+    ]
+
+    snapshot = {
+        "posts": {
+            "object_type": "table",
+            "columns": {"author": {"type": "String", "nullable": False, "default": None}},
+            "clickhouse_options": {},
+        }
+    }
+
+    issues = analyze_schema(model_tables, snapshot)
+
+    assert len(issues) == 1
+    assert issues[0].severity == "INFO"
+    assert issues[0].change_type == "add_projection"
+
+
+def test_analyze_schema_ttl_change_is_warning():
+    model_tables = [
+        ModelTable(
+            name="events",
+            columns=[ModelColumn("id", "UInt64", False, True, False, None, None)],
+            clickhouse_options={
+                "clickhouse_ttl": ["event_time + INTERVAL 1 MONTH DELETE"],
+            },
+        )
+    ]
+
+    snapshot = {
+        "events": {
+            "object_type": "table",
+            "columns": {"id": {"type": "UInt64", "nullable": False, "default": None}},
+            "clickhouse_options": {
+                "clickhouse_ttl": ["event_time + INTERVAL 1 YEAR DELETE"],
+            },
+        }
+    }
+
+    issues = analyze_schema(model_tables, snapshot)
+
+    assert len(issues) == 1
+    assert issues[0].severity == "WARNING"
+    assert issues[0].required_flag == "--force"
+
+
+def test_analyze_schema_partition_change_is_error():
+    model_tables = [
+        ModelTable(
+            name="events",
+            columns=[ModelColumn("id", "UInt64", False, True, False, None, None)],
+            clickhouse_options={
+                "clickhouse_partition_by": "toYYYYMM(event_time)",
+            },
+        )
+    ]
+
+    snapshot = {
+        "events": {
+            "object_type": "table",
+            "columns": {"id": {"type": "UInt64", "nullable": False, "default": None}},
+            "clickhouse_options": {
+                "clickhouse_partition_by": "toYYYYMM(created_at)",
+            },
+        }
+    }
+
+    issues = analyze_schema(model_tables, snapshot)
+
+    assert len(issues) == 1
+    assert issues[0].severity == "ERROR"
+
+
+def test_check_cmd_requires_force_for_warning(monkeypatch):
+    monkeypatch.setattr(
+        "dbwarden.commands.check.load_issues",
+        lambda database=None: [
+            analyze_schema(
+                [
+                    ModelTable(
+                        name="events",
+                        columns=[ModelColumn("id", "UInt64", False, True, False, None, None)],
+                        clickhouse_options={"clickhouse_ttl": ["new_ttl"]},
+                    )
+                ],
+                {
+                    "events": {
+                        "object_type": "table",
+                        "columns": {"id": {"type": "UInt64", "nullable": False, "default": None}},
+                        "clickhouse_options": {"clickhouse_ttl": ["old_ttl"]},
+                    }
+                },
+            )[0]
+        ],
+    )
+
+    try:
+        check_cmd(output_format="txt", force=False)
+    except RuntimeError as exc:
+        assert "require --force" in str(exc)
+    else:
+        raise AssertionError("Expected RuntimeError")
+
+
+def test_check_cmd_allows_warning_with_force(monkeypatch):
+    monkeypatch.setattr(
+        "dbwarden.commands.check.load_issues",
+        lambda database=None: [
+            analyze_schema(
+                [
+                    ModelTable(
+                        name="events",
+                        columns=[ModelColumn("id", "UInt64", False, True, False, None, None)],
+                        clickhouse_options={"clickhouse_ttl": ["new_ttl"]},
+                    )
+                ],
+                {
+                    "events": {
+                        "object_type": "table",
+                        "columns": {"id": {"type": "UInt64", "nullable": False, "default": None}},
+                        "clickhouse_options": {"clickhouse_ttl": ["old_ttl"]},
+                    }
+                },
+            )[0]
+        ],
+    )
+
+    check_cmd(output_format="json", force=True)

--- a/zensical.toml
+++ b/zensical.toml
@@ -90,6 +90,9 @@ name = "DBWarden on PyPI"
 "CLI Reference" = "cli-reference.md"
 
 [[project.nav]]
+"Check" = "commands/check.md"
+
+[[project.nav]]
 "Configuration API" = "reference/configuration-api.md"
 
 [project.markdown_extensions.tables]


### PR DESCRIPTION
TL;DR: Adds ClickHouse object metadata and a new safety analysis engine to DBWarden.

ClickHouse features
- Materialized views: define clickhouse_mv=True + clickhouse_mv_query; renders CREATE MATERIALIZED VIEW IF NOT EXISTS ..., handles POPULATE, dedicated engine/order/partition/TTL
- Projections: clickhouse_projections list on any CH table, rendered inline in DDL
- Drop object SQL: generate_drop_object_sql drops views with DROP VIEW, tables with DROP TABLE

Safety analyzer (dbwarden/engine/safety.py)
- Snapshot-based comparison, three severities: INFO / WARNING / ERROR
- Detects column changes, engine/order/partition/TTL changes, MV query changes, projection changes

CLI
- New dbwarden check command with --out txt|json and --force