### PR TITLE
Feature/core sandbox and dry run

### DIFF
--- a/dbwarden/cli/main.py
+++ b/dbwarden/cli/main.py
@@ -270,6 +270,12 @@ def migrate(
     backup_dir: str | None = typer.Option(
         None, "--backup-dir", help="Directory for backup files"
     ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show what would be applied without executing"
+    ),
+    sandbox: bool = typer.Option(
+        False, "--sandbox", help="Apply migrations in a temporary sandbox database"
+    ),
 ):
     """Apply pending migrations to the database."""
     validate_directory()
@@ -282,6 +288,8 @@ def migrate(
         baseline=baseline,
         with_backup=with_backup,
         backup_dir=backup_dir,
+        dry_run=dry_run,
+        sandbox=sandbox,
     )
 
 

--- a/dbwarden/commands/__init__.py
+++ b/dbwarden/commands/__init__.py
@@ -91,6 +91,8 @@ def handle_migrate(
     baseline: bool = False,
     with_backup: bool = False,
     backup_dir: str | None = None,
+    dry_run: bool = False,
+    sandbox: bool = False,
 ) -> None:
     """Handle migrate command."""
     migrate_cmd(
@@ -102,6 +104,8 @@ def handle_migrate(
         baseline=baseline,
         with_backup=with_backup,
         backup_dir=backup_dir,
+        dry_run=dry_run,
+        sandbox=sandbox,
     )
 
 

--- a/dbwarden/commands/migrate.py
+++ b/dbwarden/commands/migrate.py
@@ -138,6 +138,8 @@ def migrate_single(
     baseline: bool = False,
     with_backup: bool = False,
     backup_dir: str | None = None,
+    dry_run: bool = False,
+    sandbox: bool = False,
 ) -> None:
     """
     Apply pending migrations to a single database.
@@ -150,6 +152,8 @@ def migrate_single(
         baseline: Mark migrations as applied without executing.
         with_backup: Create a backup before migrating.
         backup_dir: Directory for backup files.
+        dry_run: Display pending migrations without executing them.
+        sandbox: Apply migrations in a temporary sandbox database instead.
     """
     from dbwarden.config import get_database
 
@@ -164,138 +168,187 @@ def migrate_single(
     if db_name:
         console.print(f"\n=== Migrating database: {db_name} ===", style="bold cyan")
 
-    if with_backup:
-        backup_directory = backup_dir or os.path.join(os.getcwd(), "backups")
-        backup_path = create_backup(sqlalchemy_url, backup_directory)
-        logger.log_backup_created(backup_path)
+    sandbox_provider = None
+    if sandbox:
+        from dbwarden.engine.sandbox import create_sandbox_provider
+        from dbwarden.database.connection import sandbox_override as _sandbox_ctx
 
-    migrations_dir = get_migrations_directory(db_name)
+        sandbox_provider = create_sandbox_provider(config.database_type)
+        sandbox_url = sandbox_provider.start()
+        sandbox_db_type = sandbox_provider.get_database_type()
+        console.print(
+            f"Sandbox started: {sandbox_provider.__class__.__name__} ({sandbox_url})",
+            style="yellow",
+        )
+        _sandbox_cm = _sandbox_ctx(sandbox_url, sandbox_db_type)
+        _sandbox_cm.__enter__()
+    else:
+        _sandbox_cm = None
 
-    create_migrations_table_if_not_exists(db_name)
-    create_lock_table_if_not_exists(db_name)
+    try:
+        if with_backup and not sandbox:
+            backup_directory = backup_dir or os.path.join(os.getcwd(), "backups")
+            backup_path = create_backup(sqlalchemy_url, backup_directory)
+            logger.log_backup_created(backup_path)
 
-    applied_versions = set(get_migrated_versions(db_name))
-    applied_checksums = get_applied_checksums(db_name)
+        migrations_dir = get_migrations_directory(db_name)
 
-    if baseline:
-        if not to_version:
-            raise ValueError("--baseline requires --to-version to be specified.")
+        if not dry_run:
+            create_migrations_table_if_not_exists(db_name)
+            create_lock_table_if_not_exists(db_name)
 
-        set_baseline_migration(migrations_dir, to_version, db_name)
-        logger.log_baseline_set(to_version)
-        console.print(f"Baseline set at version: {to_version}", style="green")
-        return
+        applied_versions = set()
+        applied_checksums = set()
+        if not dry_run:
+            applied_versions = set(get_migrated_versions(db_name))
+            applied_checksums = get_applied_checksums(db_name)
 
-    filepaths_by_version = _get_filepaths_by_version(
-        count=count,
-        to_version=to_version,
-        migrations_dir=migrations_dir,
-        applied_versions=applied_versions,
-        db_name=db_name,
-    )
+        if baseline:
+            if not to_version:
+                raise ValueError("--baseline requires --to-version to be specified.")
 
-    runs_always_filepaths = get_runs_always_filepaths(migrations_dir)
-    runs_on_change_filepaths = get_runs_on_change_filepaths(
-        migrations_dir, changed_only=True, db_name=db_name
-    )
+            set_baseline_migration(migrations_dir, to_version, db_name)
+            logger.log_baseline_set(to_version)
+            console.print(f"Baseline set at version: {to_version}", style="green")
+            return
 
-    if (
-        not filepaths_by_version
-        and not runs_always_filepaths
-        and not runs_on_change_filepaths
-    ):
-        console.print("Migrations are up to date.", style="cyan")
-        return
-
-    if filepaths_by_version:
-        logger.log_pending_migrations(list(filepaths_by_version.keys()))
-
-    versioned_count = 0
-
-    from dbwarden.engine.checksum import calculate_checksum
-
-    for version, filepath in filepaths_by_version.items():
-        filename = filepath.split("/")[-1]
-        sql_statements = parse_upgrade_statements(filepath)
-        checksum = calculate_checksum(sql_statements)
-
-        if checksum in applied_checksums:
-            logger.log_migration_skipped(version, filename, checksum)
-            continue
-
-        for sql in sql_statements:
-            logger.log_sql_statement(sql)
-
-        start_time = time.time()
-        logger.log_migration_start(version, filename)
-
-        run_migration(
-            sql_statements=sql_statements,
-            version=version,
-            migration_operation="upgrade",
-            filename=filename,
+        filepaths_by_version = _get_filepaths_by_version(
+            count=count,
+            to_version=to_version,
+            migrations_dir=migrations_dir,
+            applied_versions=applied_versions,
             db_name=db_name,
         )
 
-        duration = time.time() - start_time
-        logger.log_migration_end(version, filename, duration)
-        versioned_count += 1
-        applied_checksums.add(checksum)
+        runs_always_filepaths = get_runs_always_filepaths(migrations_dir)
+        runs_on_change_filepaths = get_runs_on_change_filepaths(
+            migrations_dir, changed_only=True, db_name=db_name
+        )
 
-    existing_runs_always = get_existing_runs_always_filenames(db_name)
-    existing_runs_on_change = get_existing_runs_on_change_filenames_to_checksums(
-        db_name
-    )
+        if (
+            not filepaths_by_version
+            and not runs_always_filepaths
+            and not runs_on_change_filepaths
+        ):
+            console.print("Migrations are up to date.", style="cyan")
+            return
 
-    for filepath in runs_always_filepaths:
-        filename = filepath.split("/")[-1]
-        sql_statements = parse_upgrade_statements(filepath)
+        if filepaths_by_version:
+            logger.log_pending_migrations(list(filepaths_by_version.keys()))
 
-        start_time = time.time()
-        logger.log_migration_start("RA", filename)
+        if dry_run:
+            console.print("[bold yellow]DRY RUN[/bold yellow] - No changes applied\n")
 
-        if filename in existing_runs_always:
+        versioned_count = 0
+
+        from dbwarden.engine.checksum import calculate_checksum
+
+        for version, filepath in filepaths_by_version.items():
+            filename = filepath.split("/")[-1]
+            sql_statements = parse_upgrade_statements(filepath)
+            checksum = calculate_checksum(sql_statements)
+
+            if checksum in applied_checksums:
+                logger.log_migration_skipped(version, filename, checksum)
+                continue
+
+            for sql in sql_statements:
+                logger.log_sql_statement(sql)
+
+            if dry_run:
+                console.print(
+                    f"  [yellow]Would apply[/yellow] version {version}: {filename}"
+                )
+                for sql in sql_statements:
+                    console.print(f"    {sql}")
+                continue
+
+            start_time = time.time()
+            logger.log_migration_start(version, filename)
+
+            run_migration(
+                sql_statements=sql_statements,
+                version=version,
+                migration_operation="upgrade",
+                filename=filename,
+                db_name=db_name,
+            )
+
+            duration = time.time() - start_time
+            logger.log_migration_end(version, filename, duration)
+            versioned_count += 1
+            applied_checksums.add(checksum)
+
+        if dry_run:
+            console.print(
+                f"\n[bold]Dry-run summary:[/bold] "
+                f"{len(filepaths_by_version)} versioned, "
+                f"{len(runs_always_filepaths)} runs-always, "
+                f"{len(runs_on_change_filepaths)} runs-on-change "
+                "migrations would be applied.\n"
+            )
+            return
+
+        existing_runs_always = get_existing_runs_always_filenames(db_name)
+        existing_runs_on_change = get_existing_runs_on_change_filenames_to_checksums(
+            db_name
+        )
+
+        for filepath in runs_always_filepaths:
+            filename = filepath.split("/")[-1]
+            sql_statements = parse_upgrade_statements(filepath)
+
+            start_time = time.time()
+            logger.log_migration_start("RA", filename)
+
+            if filename in existing_runs_always:
+                run_repeatable_migration(
+                    sql_statements=sql_statements,
+                    filename=filename,
+                    migration_type="runs_always",
+                    db_name=db_name,
+                )
+            else:
+                run_migration(
+                    sql_statements=sql_statements,
+                    version=None,
+                    migration_operation="upgrade",
+                    filename=filename,
+                    migration_type="runs_always",
+                    db_name=db_name,
+                )
+
+            duration = time.time() - start_time
+            logger.log_migration_end("RA", filename, duration)
+
+        for filepath in runs_on_change_filepaths:
+            filename = filepath.split("/")[-1]
+            sql_statements = parse_upgrade_statements(filepath)
+
+            start_time = time.time()
+            logger.log_migration_start("ROC", filename)
+
             run_repeatable_migration(
                 sql_statements=sql_statements,
                 filename=filename,
-                migration_type="runs_always",
-                db_name=db_name,
-            )
-        else:
-            run_migration(
-                sql_statements=sql_statements,
-                version=None,
-                migration_operation="upgrade",
-                filename=filename,
-                migration_type="runs_always",
+                migration_type="runs_on_change",
                 db_name=db_name,
             )
 
-        duration = time.time() - start_time
-        logger.log_migration_end("RA", filename, duration)
+            duration = time.time() - start_time
+            logger.log_migration_end("ROC", filename, duration)
 
-    for filepath in runs_on_change_filepaths:
-        filename = filepath.split("/")[-1]
-        sql_statements = parse_upgrade_statements(filepath)
-
-        start_time = time.time()
-        logger.log_migration_start("ROC", filename)
-
-        run_repeatable_migration(
-            sql_statements=sql_statements,
-            filename=filename,
-            migration_type="runs_on_change",
-            db_name=db_name,
-        )
-
-        duration = time.time() - start_time
-        logger.log_migration_end("ROC", filename, duration)
-
-    if versioned_count > 0:
-        console.print(
-            f"Migrations completed successfully: {versioned_count} migrations applied.",
-            style="green",
-        )
+        if versioned_count > 0:
+            console.print(
+                f"Migrations completed successfully: {versioned_count} migrations applied.",
+                style="green",
+            )
+    finally:
+        if sandbox_provider:
+            sandbox_provider.stop()
+            console.print("Sandbox stopped.", style="yellow")
+        if _sandbox_cm is not None:
+            _sandbox_cm.__exit__(None, None, None)
 
 
 def migrate_cmd(
@@ -307,6 +360,8 @@ def migrate_cmd(
     baseline: bool = False,
     with_backup: bool = False,
     backup_dir: str | None = None,
+    dry_run: bool = False,
+    sandbox: bool = False,
 ) -> None:
     """
     Apply pending migrations to the database.
@@ -320,6 +375,8 @@ def migrate_cmd(
         baseline: Mark migrations as applied without executing.
         with_backup: Create a backup before migrating.
         backup_dir: Directory for backup files.
+        dry_run: Display pending migrations without executing them.
+        sandbox: Apply migrations in a temporary sandbox database instead.
     """
     if count is not None and to_version is not None:
         raise ValueError("Cannot specify both 'count' and 'to-version'.")
@@ -343,6 +400,8 @@ def migrate_cmd(
                     baseline=baseline,
                     with_backup=with_backup,
                     backup_dir=backup_dir,
+                    dry_run=dry_run,
+                    sandbox=sandbox,
                 )
             except Exception as e:
                 console.print(f"Error migrating database '{db_name}': {e}", style="bold red")
@@ -356,6 +415,8 @@ def migrate_cmd(
             baseline=baseline,
             with_backup=with_backup,
             backup_dir=backup_dir,
+            dry_run=dry_run,
+            sandbox=sandbox,
         )
 
 

--- a/dbwarden/database/connection.py
+++ b/dbwarden/database/connection.py
@@ -86,6 +86,34 @@ def reset_connection_logging() -> None:
     _connection_init_logged = False
 
 
+_SANDBOX_URL: str | None = None
+_SANDBOX_DB_TYPE: str | None = None
+
+
+def set_sandbox_override(url: str, db_type: str) -> None:
+    """Set the sandbox database URL override for the current process."""
+    global _SANDBOX_URL, _SANDBOX_DB_TYPE
+    _SANDBOX_URL = url
+    _SANDBOX_DB_TYPE = db_type
+
+
+def clear_sandbox_override() -> None:
+    """Clear the sandbox database URL override."""
+    global _SANDBOX_URL, _SANDBOX_DB_TYPE
+    _SANDBOX_URL = None
+    _SANDBOX_DB_TYPE = None
+
+
+@contextmanager
+def sandbox_override(url: str, db_type: str):
+    """Context manager that temporarily sets the sandbox override."""
+    set_sandbox_override(url, db_type)
+    try:
+        yield
+    finally:
+        clear_sandbox_override()
+
+
 @contextmanager
 def get_db_connection(db_name: str | None = None) -> Generator[Any, None, None]:
     """
@@ -97,18 +125,21 @@ def get_db_connection(db_name: str | None = None) -> Generator[Any, None, None]:
     global _connection_init_logged
     config = get_database(db_name)
 
+    url = _SANDBOX_URL if _SANDBOX_URL is not None else config.sqlalchemy_url
+    db_type = _SANDBOX_DB_TYPE if _SANDBOX_DB_TYPE is not None else config.database_type
+
     from sqlalchemy.engine import make_url
-    parsed = make_url(config.sqlalchemy_url)
+    parsed = make_url(url)
     actual_db_name = db_name or (parsed.database or "default")
     logger = get_logger(
         db_name=actual_db_name,
-        db_type=config.database_type,
+        db_type=db_type,
     )
 
-    engine = _get_engine(config.sqlalchemy_url, config.database_type)
+    engine = _get_engine(url, db_type)
 
     if not _connection_init_logged:
-        logger.log_connection_init(config.database_type)
+        logger.log_connection_init(db_type)
         _connection_init_logged = True
 
     with engine.begin() as connection:

--- a/dbwarden/engine/sandbox.py
+++ b/dbwarden/engine/sandbox.py
@@ -1,0 +1,129 @@
+"""Sandbox database providers for dry-run and sandbox migration testing."""
+
+import os
+from abc import ABC, abstractmethod
+from typing import Optional
+
+
+class SandboxProvider(ABC):
+    """Abstract base class for sandbox database providers."""
+
+    @abstractmethod
+    def start(self) -> str:
+        """Start the sandbox database and return its connection URL."""
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Stop and clean up the sandbox database."""
+
+    @abstractmethod
+    def get_database_type(self) -> str:
+        """Return the database type string (e.g. 'sqlite', 'clickhouse')."""
+
+
+class SQLiteSandboxProvider(SandboxProvider):
+    """In-memory SQLite sandbox - no Docker required."""
+
+    def start(self) -> str:
+        return "sqlite:///:memory:"
+
+    def stop(self) -> None:
+        pass
+
+    def get_database_type(self) -> str:
+        return "sqlite"
+
+
+_HAS_TESTCONTAINERS: bool = False
+try:
+    import testcontainers  # noqa: F401
+    _HAS_TESTCONTAINERS = True
+except ImportError:
+    pass
+
+
+def create_sandbox_provider(database_type: str) -> SandboxProvider:
+    """Create the right sandbox provider for the given database type.
+
+    For ClickHouse, PostgreSQL, and MySQL this requires Docker and the
+    ``testcontainers`` package.  Falls back to :class:`SQLiteSandboxProvider`
+    when testcontainers is not installed.
+    """
+    if database_type == "sqlite":
+        return SQLiteSandboxProvider()
+
+    if not _HAS_TESTCONTAINERS:
+        return SQLiteSandboxProvider()
+
+    return _create_testcontainers_provider(database_type)
+
+
+def _create_testcontainers_provider(database_type: str) -> SandboxProvider:
+    if database_type == "clickhouse":
+        return ClickHouseTestcontainersProvider()
+    if database_type == "postgresql":
+        return PostgresTestcontainersProvider()
+    if database_type == "mysql":
+        return MySQLTestcontainersProvider()
+    return SQLiteSandboxProvider()
+
+
+class _TestcontainersProvider(SandboxProvider):
+    """Base for providers backed by testcontainers."""
+
+    CONTAINER_CLS = None
+    DB_DRIVER: str = ""
+    DB_TYPE: str = ""
+
+    def __init__(self) -> None:
+        self._container = None
+
+    def start(self) -> str:
+        if self.CONTAINER_CLS is None:
+            return SQLiteSandboxProvider().start()
+
+        tc = __import__("testcontainers", fromlist=[self.CONTAINER_CLS])
+        cls = getattr(tc, self.CONTAINER_CLS)
+        self._container = cls()
+        self._container.start()
+        return self._build_url()
+
+    def stop(self) -> None:
+        if self._container is not None:
+            self._container.stop()
+            self._container = None
+
+    def get_database_type(self) -> str:
+        return self.DB_TYPE
+
+    def _build_url(self) -> str:
+        raise NotImplementedError
+
+
+class ClickHouseTestcontainersProvider(_TestcontainersProvider):
+    CONTAINER_CLS = "ClickHouseContainer"
+    DB_DRIVER = "clickhousedb"
+    DB_TYPE = "clickhouse"
+
+    def _build_url(self) -> str:
+        port = self._container.get_exposed_port(8123)
+        host = self._container.get_container_host_ip()
+        return f"clickhousedb://default:@:{port}/default"
+
+
+class PostgresTestcontainersProvider(_TestcontainersProvider):
+    CONTAINER_CLS = "PostgresContainer"
+    DB_DRIVER = "postgresql"
+    DB_TYPE = "postgresql"
+
+    def _build_url(self) -> str:
+        return self._container.get_connection_url()
+
+
+class MySQLTestcontainersProvider(_TestcontainersProvider):
+    CONTAINER_CLS = "MySQLContainer"
+    DB_DRIVER = "mysql"
+    DB_TYPE = "mysql"
+
+    def _build_url(self) -> str:
+        return self._container.get_connection_url()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ sqlite = [
 clickhouse = [
     "clickhouse-connect>=0.7.15",
 ]
+sandbox = [
+    "testcontainers>=4.0.0",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["dbwarden"]

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,247 @@
+import os
+import sys
+import tempfile
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from dbwarden.engine.sandbox import SQLiteSandboxProvider, create_sandbox_provider
+
+
+class TestSQLiteSandboxProvider:
+    def test_start_returns_in_memory_url(self):
+        provider = SQLiteSandboxProvider()
+        url = provider.start()
+        assert url == "sqlite:///:memory:"
+
+    def test_stop_does_not_raise(self):
+        provider = SQLiteSandboxProvider()
+        provider.start()
+        provider.stop()
+
+    def test_get_database_type(self):
+        provider = SQLiteSandboxProvider()
+        assert provider.get_database_type() == "sqlite"
+
+    def test_start_and_stop_can_be_called_multiple_times(self):
+        provider = SQLiteSandboxProvider()
+        url1 = provider.start()
+        provider.stop()
+        url2 = provider.start()
+        provider.stop()
+        assert url1 == url2 == "sqlite:///:memory:"
+
+
+class TestCreateSandboxProvider:
+    def test_sqlite_returns_sqlite_provider(self):
+        provider = create_sandbox_provider("sqlite")
+        assert isinstance(provider, SQLiteSandboxProvider)
+
+    def test_unknown_type_returns_sqlite_fallback(self):
+        provider = create_sandbox_provider("unknown")
+        assert isinstance(provider, SQLiteSandboxProvider)
+
+    def test_clickhouse_without_testcontainers_returns_sqlite(self):
+        provider = create_sandbox_provider("clickhouse")
+        assert isinstance(provider, SQLiteSandboxProvider)
+
+    def test_provider_start_and_stop(self):
+        provider = create_sandbox_provider("sqlite")
+        url = provider.start()
+        assert url == "sqlite:///:memory:"
+        provider.stop()
+
+
+def _write_migration(directory: str, name: str, content: str) -> None:
+    with open(os.path.join(directory, name), "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+class TestDryRun:
+    def test_dry_run_prints_pending_and_skips_execution(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                db_path = os.path.join(tmpdir, "app.db")
+                Path("dbwarden.py").write_text(
+                    "from dbwarden import database_config\n\n"
+                    "database_config(database_name='primary', default=True, "
+                    "database_type='sqlite', database_url='sqlite:///" + db_path + "')\n",
+                    encoding="utf-8",
+                )
+                migrations_dir = Path("migrations/primary")
+                migrations_dir.mkdir(parents=True)
+                _write_migration(
+                    str(migrations_dir),
+                    "primary__0001_create_test.sql",
+                    "-- upgrade\n\n"
+                    "CREATE TABLE test (id INTEGER PRIMARY KEY)\n"
+                    "INSERT INTO test VALUES (1)\n\n"
+                    "-- rollback\n\n"
+                    "DROP TABLE test\n",
+                )
+
+                from dbwarden.commands.migrate import migrate_single
+
+                old_stdout = sys.stdout
+                sys.stdout = StringIO()
+                try:
+                    migrate_single(db_name="primary", dry_run=True)
+                    output = sys.stdout.getvalue()
+                finally:
+                    sys.stdout = old_stdout
+
+                assert "DRY RUN" in output
+                assert "0001" in output
+                assert "CREATE TABLE test" in output
+
+                assert not os.path.exists(db_path)
+            finally:
+                os.chdir(old_cwd)
+
+    def test_dry_run_no_pending_migrations(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                db_path = os.path.join(tmpdir, "app.db")
+                Path("dbwarden.py").write_text(
+                    "from dbwarden import database_config\n\n"
+                    "database_config(database_name='primary', default=True, "
+                    "database_type='sqlite', database_url='sqlite:///" + db_path + "')\n",
+                    encoding="utf-8",
+                )
+                migrations_dir = Path("migrations/primary")
+                migrations_dir.mkdir(parents=True)
+
+                from dbwarden.commands.migrate import migrate_single
+
+                old_stdout = sys.stdout
+                sys.stdout = StringIO()
+                try:
+                    migrate_single(db_name="primary", dry_run=True)
+                    output = sys.stdout.getvalue()
+                finally:
+                    sys.stdout = old_stdout
+
+                assert "up to date" in output.lower()
+            finally:
+                os.chdir(old_cwd)
+
+
+class TestSandbox:
+    def test_sandbox_applies_migrations_and_cleans_up(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                db_path = os.path.join(tmpdir, "app.db")
+                Path("dbwarden.py").write_text(
+                    "from dbwarden import database_config\n\n"
+                    "database_config(database_name='primary', default=True, "
+                    "database_type='sqlite', database_url='sqlite:///" + db_path + "')\n",
+                    encoding="utf-8",
+                )
+                migrations_dir = Path("migrations/primary")
+                migrations_dir.mkdir(parents=True)
+                _write_migration(
+                    str(migrations_dir),
+                    "primary__0001_create_test.sql",
+                    "-- upgrade\n\n"
+                    "CREATE TABLE test (id INTEGER PRIMARY KEY)\n\n"
+                    "-- rollback\n\n"
+                    "DROP TABLE test\n",
+                )
+
+                from dbwarden.commands.migrate import migrate_single
+
+                old_stdout = sys.stdout
+                sys.stdout = StringIO()
+                try:
+                    migrate_single(db_name="primary", sandbox=True)
+                    output = sys.stdout.getvalue()
+                finally:
+                    sys.stdout = old_stdout
+
+                assert "Sandbox started" in output
+                assert "Sandbox stopped" in output
+                assert "completed successfully" in output.lower()
+
+                assert not os.path.exists(db_path)
+            finally:
+                os.chdir(old_cwd)
+
+    def test_sandbox_reports_no_pending(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                db_path = os.path.join(tmpdir, "app.db")
+                Path("dbwarden.py").write_text(
+                    "from dbwarden import database_config\n\n"
+                    "database_config(database_name='primary', default=True, "
+                    "database_type='sqlite', database_url='sqlite:///" + db_path + "')\n",
+                    encoding="utf-8",
+                )
+                migrations_dir = Path("migrations/primary")
+                migrations_dir.mkdir(parents=True)
+
+                from dbwarden.commands.migrate import migrate_single
+
+                old_stdout = sys.stdout
+                sys.stdout = StringIO()
+                try:
+                    migrate_single(db_name="primary", sandbox=True)
+                    output = sys.stdout.getvalue()
+                finally:
+                    sys.stdout = old_stdout
+
+                assert "Sandbox started" in output
+                assert "Sandbox stopped" in output
+                assert "up to date" in output.lower()
+            finally:
+                os.chdir(old_cwd)
+
+    def test_sandbox_isolates_from_real_db(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                db_path = os.path.join(tmpdir, "app.db")
+                Path("dbwarden.py").write_text(
+                    "from dbwarden import database_config\n\n"
+                    "database_config(database_name='primary', default=True, "
+                    "database_type='sqlite', database_url='sqlite:///" + db_path + "')\n",
+                    encoding="utf-8",
+                )
+                migrations_dir = Path("migrations/primary")
+                migrations_dir.mkdir(parents=True)
+                _write_migration(
+                    str(migrations_dir),
+                    "primary__0001_create_test.sql",
+                    "-- upgrade\n\n"
+                    "CREATE TABLE test (id INTEGER PRIMARY KEY)\n\n"
+                    "-- rollback\n\n"
+                    "DROP TABLE test\n",
+                )
+
+                from dbwarden.commands.migrate import migrate_single
+                from dbwarden.database.connection import _engine_cache
+
+                migrate_single(db_name="primary", sandbox=True)
+
+                assert not os.path.exists(db_path)
+
+                from sqlalchemy import create_engine, text
+
+                real_engine = create_engine(f"sqlite:///{db_path}")
+                from sqlalchemy import inspect as sa_inspect
+
+                inspector = sa_inspect(real_engine)
+                tables = inspector.get_table_names()
+                assert "test" not in tables
+                real_engine.dispose()
+            finally:
+                os.chdir(old_cwd)


### PR DESCRIPTION
Adds a `SandboxProvider` interface with SQLite and Docker-backed
(testcontainers) implementations for ClickHouse, PostgreSQL, MySQL.

### New
- `dbwarden/engine/sandbox.py`: `SandboxProvider`, `SQLiteSandboxProvider`,
  Docker-backed providers, `sandbox_override()` context manager
- `dbwarden migrate --sandbox <provider>`: run migrations against an
  ephemeral sandbox database
- `dbwarden migrate --dry-run`: show SQL without executing
- Optional `sandbox` extra (`pip install dbwarden[sandbox]`) for
  testcontainers support
