### PR TITLE
feat: split database_url into sync/async, add async_session + sync_session

### DIFF
--- a/dbwarden/commands/init.py
+++ b/dbwarden/commands/init.py
@@ -62,7 +62,7 @@ def _ensure_settings_file(settings_path: Path, db_name: str) -> None:
             f'    database_name="{db_name}",\n'
             "    default=True,\n"
             '    database_type="sqlite",\n'
-            '    database_url="sqlite:///./app.db",\n'
+            '    database_url_sync="sqlite:///./app.db",\n'
             f'    migrations_dir="migrations/{db_name}",\n'
             ")\n"
         )

--- a/dbwarden/commands/settings.py
+++ b/dbwarden/commands/settings.py
@@ -63,7 +63,8 @@ def _entry_kwargs(entry: DatabaseEntry) -> dict[str, Any]:
     return {
         "database_name": entry.database_name,
         "database_type": entry.database_type,
-        "database_url": entry.database_url,
+        "database_url_sync": entry.database_url_sync,
+        "database_url_async": entry.database_url_async,
         "secure_values": entry.secure_values,
         "default": entry.default,
         "migrations_dir": entry.migrations_dir,
@@ -81,7 +82,8 @@ def _render_entry(entry: DatabaseEntry) -> str:
         "database_name",
         "default",
         "database_type",
-        "database_url",
+        "database_url_sync",
+        "database_url_async",
         "secure_values",
         "migrations_dir",
         "migration_table",
@@ -164,7 +166,7 @@ def handle_settings_show(database: str | None = None, all_databases: bool = Fals
                     str(display_value(db, "database_type", db.database_type))
                 ),
             )
-            _print_field("URL", display_value(db, "database_url", db.sqlalchemy_url))
+            _print_field("URL", display_value(db, "database_url_sync", db.sqlalchemy_url))
             _print_field(
                 "Migrations Directory",
                 display_value(db, "migrations_dir", db.migrations_dir),
@@ -201,7 +203,7 @@ def handle_settings_show(database: str | None = None, all_databases: bool = Fals
         "Type",
         _display_db_type(str(display_value(db, "database_type", db.database_type))),
     )
-    _print_field("URL", display_value(db, "database_url", db.sqlalchemy_url))
+    _print_field("URL", display_value(db, "database_url_sync", db.sqlalchemy_url))
     _print_field(
         "Migrations Directory",
         display_value(db, "migrations_dir", db.migrations_dir),
@@ -263,7 +265,7 @@ def handle_settings_database_add(
         {
             "database_name": name,
             "database_type": database_type,
-            "database_url": url,
+            "database_url_sync": url,
             "migrations_dir": migrations_dir,
             "migration_table": migration_table,
             "model_paths": model_paths,

--- a/dbwarden/commands/utils.py
+++ b/dbwarden/commands/utils.py
@@ -16,7 +16,7 @@ def config_cmd() -> None:
         marker = " (default)" if name == config.default else ""
         database_url = display_value(
             db,
-            "database_url",
+            "database_url_sync",
             _mask_password(db.sqlalchemy_url),
         )
         console.print(f"  - {name}{marker}", style="cyan")
@@ -25,7 +25,7 @@ def config_cmd() -> None:
             style="white",
         )
         console.print(
-            f"    database_url: {database_url}",
+            f"    database_url_sync: {database_url}",
             style="white",
             markup=False,
             highlight=False,

--- a/dbwarden/config.py
+++ b/dbwarden/config.py
@@ -33,8 +33,9 @@ _IGNORE_DIRS = {
 
 @dataclass
 class DatabaseConfig:
-    sqlalchemy_url: str
     database_type: DatabaseType
+    sqlalchemy_url_sync: str | None = None
+    sqlalchemy_url_async: str | None = None
     secure_values: bool = False
     secure_display_values: dict[str, str] = field(default_factory=dict)
     model_paths: list[str] | None = None
@@ -44,6 +45,15 @@ class DatabaseConfig:
     dev_database_url: str | None = None
     dev_database_type: DatabaseType | None = None
     overlap_models: bool = False
+
+    @property
+    def sqlalchemy_url(self) -> str:
+        """Backward-compat: sync URL (used by migration engine)."""
+        if self.sqlalchemy_url_sync is not None:
+            return self.sqlalchemy_url_sync
+        if self.sqlalchemy_url_async:
+            return self.sqlalchemy_url_async
+        return ""
 
 
 @dataclass
@@ -352,24 +362,43 @@ def _finalize_entries(
             )
         migration_owners[migrations_dir] = entry.database_name
 
-        normalized_url = _normalized_url(entry.database_url)
-        if normalized_url in url_owners:
-            raise ConfigurationError(
-                f"Duplicate database_url: '{entry.database_url}'"
-            )
-        url_owners[normalized_url] = entry.database_name
+        if entry.database_url_sync:
+            normalized_url = _normalized_url(entry.database_url_sync)
+            if normalized_url in url_owners:
+                raise ConfigurationError(
+                    f"Duplicate database_url_sync: '{entry.database_url_sync}'"
+                )
+            url_owners[normalized_url] = entry.database_name
 
-        target_key = _build_database_target_key(
-            entry.database_url,
-            entry.database_type,
-            base_dir,
-        )
-        if target_key in target_owners:
-            raise ConfigurationError(
-                "Duplicate database target detected: "
-                f"'{entry.database_name}' collides with '{target_owners[target_key]}'"
+            target_key = _build_database_target_key(
+                entry.database_url_sync,
+                entry.database_type,
+                base_dir,
             )
-        target_owners[target_key] = entry.database_name
+            if target_key in target_owners:
+                raise ConfigurationError(
+                    "Duplicate database target detected: "
+                    f"'{entry.database_name}' collides with '{target_owners[target_key]}'"
+                )
+            target_owners[target_key] = entry.database_name
+
+        if entry.database_url_async:
+            async_target_key = _build_database_target_key(
+                entry.database_url_async,
+                entry.database_type,
+                base_dir,
+            )
+            if async_target_key in target_owners:
+                raise ConfigurationError(
+                    "Duplicate database target detected for async URL: "
+                    f"'{entry.database_name}' collides with '{target_owners[async_target_key]}'"
+                )
+            target_owners[async_target_key] = entry.database_name
+
+        if not entry.database_url_sync and not entry.database_url_async:
+            raise ConfigurationError(
+                f"At least one of database_url_sync or database_url_async must be provided for '{entry.database_name}'."
+            )
 
         if entry.dev_database_type and not entry.dev_database_url:
             raise ConfigurationError(
@@ -406,7 +435,8 @@ def _finalize_entries(
                 secure_display_values = variable_value_expressions[index]
 
         databases[entry.database_name] = DatabaseConfig(
-            sqlalchemy_url=entry.database_url,
+            sqlalchemy_url_sync=entry.database_url_sync,
+            sqlalchemy_url_async=entry.database_url_async,
             database_type=entry.database_type,
             secure_values=entry.secure_values,
             secure_display_values=secure_display_values,
@@ -484,7 +514,7 @@ def get_database(name: str | None = None) -> DatabaseConfig:
 
     return replace(
         selected,
-        sqlalchemy_url=selected.dev_database_url,
+        sqlalchemy_url_sync=selected.dev_database_url,
         database_type=dev_database_type,
     )
 

--- a/dbwarden/config_registry.py
+++ b/dbwarden/config_registry.py
@@ -41,6 +41,9 @@ def registered_entries() -> list[DatabaseEntry]:
     return _REGISTRY.entries()
 
 
-def database_config(**kwargs) -> None:
+def database_config(**kwargs) -> "DatabaseHandle":
     entry = structure_database_entry(kwargs)
     _REGISTRY.add(entry)
+    from dbwarden.db_handle import DatabaseHandle
+
+    return DatabaseHandle(entry.database_name, entry.database_type)

--- a/dbwarden/config_registry.py
+++ b/dbwarden/config_registry.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
-from dbwarden.config_schema import DatabaseEntry, structure_database_entry
+from dbwarden.config_schema import DatabaseEntry, DatabaseType, structure_database_entry
+
+if TYPE_CHECKING:
+    from dbwarden.db_handle import DatabaseHandle
 
 
 @dataclass
@@ -41,9 +44,38 @@ def registered_entries() -> list[DatabaseEntry]:
     return _REGISTRY.entries()
 
 
-def database_config(**kwargs) -> "DatabaseHandle":
-    entry = structure_database_entry(kwargs)
-    _REGISTRY.add(entry)
-    from dbwarden.db_handle import DatabaseHandle
+def database_config(
+    *,
+    database_name: str,
+    database_type: DatabaseType = "sqlite",
+    database_url_sync: str | None = None,
+    database_url_async: str | None = None,
+    secure_values: bool = False,
+    default: bool = False,
+    migrations_dir: str | None = None,
+    migration_table: str | None = None,
+    model_paths: list[str] | None = None,
+    dev_database_type: DatabaseType | None = None,
+    dev_database_url: str | None = None,
+    overlap_models: bool = False,
+) -> DatabaseHandle:
+    from dbwarden.db_handle import DatabaseHandle as _DH
 
-    return DatabaseHandle(entry.database_name, entry.database_type)
+    entry = structure_database_entry(
+        dict(
+            database_name=database_name,
+            database_type=database_type,
+            database_url_sync=database_url_sync,
+            database_url_async=database_url_async,
+            secure_values=secure_values,
+            default=default,
+            migrations_dir=migrations_dir,
+            migration_table=migration_table,
+            model_paths=model_paths,
+            dev_database_type=dev_database_type,
+            dev_database_url=dev_database_url,
+            overlap_models=overlap_models,
+        )
+    )
+    _REGISTRY.add(entry)
+    return _DH(entry.database_name, entry.database_type)

--- a/dbwarden/config_schema.py
+++ b/dbwarden/config_schema.py
@@ -77,7 +77,14 @@ def _validate_migration_table(_self, _attribute, value: str | None) -> None:
 class DatabaseEntry:
     database_name: str = field(validator=_validate_database_name)
     database_type: DatabaseType = field(validator=_validate_database_type)
-    database_url: str = field(validator=validators.min_len(1))
+    database_url_sync: str | None = None
+    database_url_async: str | None = None
+
+    def __attrs_post_init__(self) -> None:
+        if not self.database_url_sync and not self.database_url_async:
+            raise ValueError(
+                "At least one of database_url_sync or database_url_async must be provided."
+            )
     secure_values: bool = False
     default: bool = False
     migrations_dir: str | None = None
@@ -98,6 +105,12 @@ _CONVERTER = cattrs.Converter(detailed_validation=True)
 
 
 def structure_database_entry(kwargs: dict) -> DatabaseEntry:
+    sync = kwargs.get("database_url_sync")
+    async_ = kwargs.get("database_url_async")
+    if not sync and not async_:
+        raise ConfigurationError(
+            "At least one of database_url_sync or database_url_async must be provided."
+        )
     try:
         return _CONVERTER.structure(kwargs, DatabaseEntry)
     except Exception as exc:

--- a/dbwarden/db_handle.py
+++ b/dbwarden/db_handle.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING, Annotated
+
+if TYPE_CHECKING:
+    from clickhouse_connect.driver.asyncclient import AsyncClient
+    from fastapi import Depends
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class DatabaseHandle:
+    """Handle returned by ``database_config()``.
+
+    The ``.session`` property returns a type annotation FastAPI can
+    consume directly as a route parameter type hint — no ``Annotated``,
+    ``Depends``, or typing imports needed in the route module::
+
+        # dbwarden.py
+        from dbwarden import database_config
+        primary = database_config(database_name="primary", ...)
+
+        # routes.py
+        from ..dbwarden import primary
+
+        @router.get("/users")
+        async def users(session: primary.session):
+            ...
+    """
+
+    def __init__(self, name: str, db_type: str) -> None:
+        self._name = name
+        self._db_type = db_type
+
+    @functools.cached_property
+    def session(self):
+        """Return ``Annotated[T, Depends(...)]`` for the database type.
+
+        * PostgreSQL / SQLite / MySQL / MariaDB  → ``AsyncSession``
+        * ClickHouse                              → ``AsyncClient``
+        """
+        if self._db_type in ("postgresql", "sqlite", "mysql", "mariadb"):
+            from fastapi import Depends
+            from sqlalchemy.ext.asyncio import AsyncSession
+
+            from dbwarden.fastapi.async_db import _make_session_dep
+
+            return Annotated[
+                AsyncSession, Depends(_make_session_dep(self._name))
+            ]
+
+        if self._db_type == "clickhouse":
+            from fastapi import Depends
+            from clickhouse_connect.driver.asyncclient import AsyncClient
+
+            from dbwarden.fastapi.async_db import _make_clickhouse_dep
+
+            return Annotated[
+                AsyncClient, Depends(_make_clickhouse_dep(self._name))
+            ]
+
+        raise ValueError(
+            f"Unsupported database_type: {self._db_type!r}. "
+            f"Expected one of: sqlite, postgresql, mysql, mariadb, clickhouse."
+        )

--- a/dbwarden/db_handle.py
+++ b/dbwarden/db_handle.py
@@ -5,16 +5,17 @@ from typing import TYPE_CHECKING, Annotated
 
 if TYPE_CHECKING:
     from clickhouse_connect.driver.asyncclient import AsyncClient
-    from fastapi import Depends
+    from clickhouse_connect.driver.client import Client as SyncClickHouseClient
+    from fastapi.params import Depends
     from sqlalchemy.ext.asyncio import AsyncSession
+    from sqlalchemy.orm import Session
 
 
 class DatabaseHandle:
     """Handle returned by ``database_config()``.
 
-    The ``.session`` property returns a type annotation FastAPI can
-    consume directly as a route parameter type hint — no ``Annotated``,
-    ``Depends``, or typing imports needed in the route module::
+    The ``.async_session`` and ``.sync_session`` properties return type
+    annotations FastAPI can consume directly as route parameter type hints::
 
         # dbwarden.py
         from dbwarden import database_config
@@ -24,7 +25,11 @@ class DatabaseHandle:
         from ..dbwarden import primary
 
         @router.get("/users")
-        async def users(session: primary.session):
+        async def users(session: primary.async_session):
+            ...
+
+        @router.get("/items")
+        def items(session: primary.sync_session):
             ...
     """
 
@@ -33,17 +38,17 @@ class DatabaseHandle:
         self._db_type = db_type
 
     @functools.cached_property
-    def session(self):
-        """Return ``Annotated[T, Depends(...)]`` for the database type.
+    def async_session(self) -> Annotated[AsyncSession | AsyncClient, Depends]:
+        """FastAPI dependency annotation for async database access.
 
-        * PostgreSQL / SQLite / MySQL / MariaDB  → ``AsyncSession``
-        * ClickHouse                              → ``AsyncClient``
+        Resolves to ``Annotated[AsyncSession, Depends(...)]`` for SQL databases
+        or ``Annotated[AsyncClient, Depends(...)]`` for ClickHouse.
         """
         if self._db_type in ("postgresql", "sqlite", "mysql", "mariadb"):
             from fastapi import Depends
             from sqlalchemy.ext.asyncio import AsyncSession
 
-            from dbwarden.fastapi.async_db import _make_session_dep
+            from dbwarden.fastapi.engines import _make_session_dep
 
             return Annotated[
                 AsyncSession, Depends(_make_session_dep(self._name))
@@ -53,7 +58,7 @@ class DatabaseHandle:
             from fastapi import Depends
             from clickhouse_connect.driver.asyncclient import AsyncClient
 
-            from dbwarden.fastapi.async_db import _make_clickhouse_dep
+            from dbwarden.fastapi.engines import _make_clickhouse_dep
 
             return Annotated[
                 AsyncClient, Depends(_make_clickhouse_dep(self._name))
@@ -63,3 +68,48 @@ class DatabaseHandle:
             f"Unsupported database_type: {self._db_type!r}. "
             f"Expected one of: sqlite, postgresql, mysql, mariadb, clickhouse."
         )
+
+    @functools.cached_property
+    def sync_session(self) -> Annotated[Session | SyncClickHouseClient, Depends]:
+        """FastAPI dependency annotation for synchronous database access.
+
+        Resolves to ``Annotated[Session, Depends(...)]`` for SQL databases
+        or ``Annotated[Client, Depends(...)]`` for ClickHouse.
+        """
+
+        if self._db_type in ("postgresql", "sqlite", "mysql", "mariadb"):
+            from fastapi import Depends
+            from sqlalchemy.orm import Session
+
+            from dbwarden.fastapi.engines import _make_sync_session_dep
+
+            return Annotated[
+                Session, Depends(_make_sync_session_dep(self._name))
+            ]
+
+        if self._db_type == "clickhouse":
+            from fastapi import Depends
+            from clickhouse_connect.driver.client import Client as SyncClickHouseClient
+
+            from dbwarden.fastapi.engines import _make_sync_clickhouse_dep
+
+            return Annotated[
+                SyncClickHouseClient, Depends(_make_sync_clickhouse_dep(self._name))
+            ]
+
+        raise ValueError(
+            f"Unsupported database_type: {self._db_type!r}. "
+            f"Expected one of: sqlite, postgresql, mysql, mariadb, clickhouse."
+        )
+
+    @property
+    def session(self) -> Annotated[AsyncSession | AsyncClient, Depends]:
+        """Deprecated: use ``async_session`` or ``sync_session``."""
+        import warnings
+
+        warnings.warn(
+            "DatabaseHandle.session is deprecated; use .async_session or .sync_session",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.async_session

--- a/dbwarden/fastapi/__init__.py
+++ b/dbwarden/fastapi/__init__.py
@@ -1,4 +1,4 @@
-from dbwarden.fastapi.async_db import dispose_engines
+from dbwarden.fastapi.engines import dispose_engines
 from dbwarden.fastapi.context import check_schema_on_startup, migrate_on_startup, migration_context
 from dbwarden.fastapi.health import DBWardenHealthRouter
 from dbwarden.fastapi.session import get_session

--- a/dbwarden/fastapi/__init__.py
+++ b/dbwarden/fastapi/__init__.py
@@ -1,9 +1,11 @@
+from dbwarden.fastapi.async_db import dispose_engines
 from dbwarden.fastapi.context import check_schema_on_startup, migrate_on_startup, migration_context
 from dbwarden.fastapi.health import DBWardenHealthRouter
 from dbwarden.fastapi.session import get_session
 
 __all__ = [
     "get_session",
+    "dispose_engines",
     "check_schema_on_startup",
     "migrate_on_startup",
     "migration_context",

--- a/dbwarden/fastapi/async_db.py
+++ b/dbwarden/fastapi/async_db.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import threading
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from sqlalchemy.engine import make_url
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dbwarden.config import get_database
+from dbwarden.fastapi.runtime import runtime_flags
+
+_SESSION_FACTORIES: dict[str, async_sessionmaker[AsyncSession]] = {}
+_CLICKHOUSE_CLIENTS: dict[str, Any] = {}
+_LOCK = threading.Lock()
+
+
+def _to_async_url(url: str, database_type: str) -> tuple[str, str]:
+    """Convert URL to async driver format.
+
+    Returns:
+        Tuple of (safe_cache_key, async_url).
+    """
+    parsed = make_url(url)
+    safe_key = parsed.render_as_string(hide_password=True)
+
+    if "+" in parsed.drivername:
+        return safe_key, parsed.render_as_string(hide_password=False)
+
+    if database_type in ("postgresql",) or parsed.drivername.startswith("postgres"):
+        drivername = "postgresql+asyncpg"
+    elif database_type in ("sqlite",) or parsed.drivername.startswith("sqlite"):
+        drivername = "sqlite+aiosqlite"
+    else:
+        raise ValueError(
+            f"get_session currently supports async PostgreSQL and SQLite drivers. "
+            f"Unsupported database_type: {database_type}"
+        )
+
+    full_url = parsed.set(drivername=drivername).render_as_string(hide_password=False)
+    return safe_key, full_url
+
+
+def _session_factory(name: str, dev: bool = False) -> async_sessionmaker[AsyncSession]:
+    with runtime_flags(dev=dev, strict_translation=False):
+        config = get_database(name)
+
+    cache_key, async_url = _to_async_url(config.sqlalchemy_url, config.database_type)
+
+    with _LOCK:
+        if cache_key in _SESSION_FACTORIES:
+            return _SESSION_FACTORIES[cache_key]
+
+        engine = create_async_engine(async_url, future=True)
+        factory = async_sessionmaker(
+            bind=engine, class_=AsyncSession, expire_on_commit=False
+        )
+        _SESSION_FACTORIES[cache_key] = factory
+        return factory
+
+
+def _make_session_dep(name: str, dev: bool = False):
+    """Return a FastAPI dependency that yields a new AsyncSession per request."""
+
+    async def _dependency() -> AsyncGenerator[AsyncSession, None]:
+        factory = _session_factory(name, dev=dev)
+        async with factory() as session:
+            yield session
+
+    return _dependency
+
+
+def _parse_clickhouse_url(url: str) -> dict[str, Any]:
+    """Parse a ClickHouse URL into connection kwargs."""
+    parsed = make_url(url)
+    kwargs: dict[str, Any] = {
+        "host": parsed.host or "localhost",
+        "port": parsed.port or 8123,
+        "database": parsed.database or "default",
+    }
+    if parsed.username:
+        kwargs["username"] = parsed.username
+    if parsed.password:
+        kwargs["password"] = parsed.password
+    return kwargs
+
+
+def _make_clickhouse_dep(name: str, dev: bool = False):
+    """Return a FastAPI dependency that yields a shared AsyncClient."""
+
+    async def _dependency() -> AsyncGenerator[Any, None]:
+        if name not in _CLICKHOUSE_CLIENTS:
+            import clickhouse_connect
+
+            with runtime_flags(dev=dev, strict_translation=False):
+                config = get_database(name)
+
+            conn_kwargs = _parse_clickhouse_url(config.sqlalchemy_url)
+            client = await clickhouse_connect.get_async_client(**conn_kwargs)
+            _CLICKHOUSE_CLIENTS[name] = client
+
+        yield _CLICKHOUSE_CLIENTS[name]
+
+    return _dependency
+
+
+def dispose_engines() -> None:
+    """Close all cached async engines and ClickHouse clients.
+
+    Call during FastAPI shutdown:
+
+        @asynccontextmanager
+        async def lifespan(app: FastAPI):
+            yield
+            dispose_engines()
+    """
+    _CLICKHOUSE_CLIENTS.clear()
+    _SESSION_FACTORIES.clear()

--- a/dbwarden/fastapi/engines.py
+++ b/dbwarden/fastapi/engines.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
 import threading
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Generator
 from typing import Any
 
-from sqlalchemy.engine import make_url
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine, make_url
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import Session, sessionmaker
 
 from dbwarden.config import get_database
 from dbwarden.fastapi.runtime import runtime_flags
 
-_SESSION_FACTORIES: dict[str, async_sessionmaker[AsyncSession]] = {}
-_CLICKHOUSE_CLIENTS: dict[str, Any] = {}
+_ASYNC_SESSION_FACTORIES: dict[str, async_sessionmaker[AsyncSession]] = {}
+_SYNC_SESSION_FACTORIES: dict[str, sessionmaker[Session]] = {}
+_CLICKHOUSE_ASYNC_CLIENTS: dict[str, Any] = {}
+_CLICKHOUSE_SYNC_CLIENTS: dict[str, Any] = {}
 _LOCK = threading.Lock()
 
 
@@ -41,21 +45,22 @@ def _to_async_url(url: str, database_type: str) -> tuple[str, str]:
     return safe_key, full_url
 
 
-def _session_factory(name: str, dev: bool = False) -> async_sessionmaker[AsyncSession]:
+def _async_session_factory(name: str, dev: bool = False) -> async_sessionmaker[AsyncSession]:
     with runtime_flags(dev=dev, strict_translation=False):
         config = get_database(name)
 
-    cache_key, async_url = _to_async_url(config.sqlalchemy_url, config.database_type)
+    url = config.sqlalchemy_url_async or config.sqlalchemy_url
+    cache_key, async_url = _to_async_url(url, config.database_type)
 
     with _LOCK:
-        if cache_key in _SESSION_FACTORIES:
-            return _SESSION_FACTORIES[cache_key]
+        if cache_key in _ASYNC_SESSION_FACTORIES:
+            return _ASYNC_SESSION_FACTORIES[cache_key]
 
         engine = create_async_engine(async_url, future=True)
         factory = async_sessionmaker(
             bind=engine, class_=AsyncSession, expire_on_commit=False
         )
-        _SESSION_FACTORIES[cache_key] = factory
+        _ASYNC_SESSION_FACTORIES[cache_key] = factory
         return factory
 
 
@@ -63,8 +68,35 @@ def _make_session_dep(name: str, dev: bool = False):
     """Return a FastAPI dependency that yields a new AsyncSession per request."""
 
     async def _dependency() -> AsyncGenerator[AsyncSession, None]:
-        factory = _session_factory(name, dev=dev)
+        factory = _async_session_factory(name, dev=dev)
         async with factory() as session:
+            yield session
+
+    return _dependency
+
+
+def _sync_session_factory(name: str, dev: bool = False) -> sessionmaker[Session]:
+    with runtime_flags(dev=dev, strict_translation=False):
+        config = get_database(name)
+
+    url = config.sqlalchemy_url_sync or config.sqlalchemy_url
+
+    with _LOCK:
+        if url in _SYNC_SESSION_FACTORIES:
+            return _SYNC_SESSION_FACTORIES[url]
+
+        engine = create_engine(url)
+        factory = sessionmaker(bind=engine)
+        _SYNC_SESSION_FACTORIES[url] = factory
+        return factory
+
+
+def _make_sync_session_dep(name: str, dev: bool = False):
+    """Return a FastAPI dependency that yields a new sync Session per request."""
+
+    def _dependency() -> Generator[Session, None, None]:
+        factory = _sync_session_factory(name, dev=dev)
+        with factory() as session:
             yield session
 
     return _dependency
@@ -89,7 +121,7 @@ def _make_clickhouse_dep(name: str, dev: bool = False):
     """Return a FastAPI dependency that yields a shared AsyncClient."""
 
     async def _dependency() -> AsyncGenerator[Any, None]:
-        if name not in _CLICKHOUSE_CLIENTS:
+        if name not in _CLICKHOUSE_ASYNC_CLIENTS:
             import clickhouse_connect
 
             with runtime_flags(dev=dev, strict_translation=False):
@@ -97,15 +129,34 @@ def _make_clickhouse_dep(name: str, dev: bool = False):
 
             conn_kwargs = _parse_clickhouse_url(config.sqlalchemy_url)
             client = await clickhouse_connect.get_async_client(**conn_kwargs)
-            _CLICKHOUSE_CLIENTS[name] = client
+            _CLICKHOUSE_ASYNC_CLIENTS[name] = client
 
-        yield _CLICKHOUSE_CLIENTS[name]
+        yield _CLICKHOUSE_ASYNC_CLIENTS[name]
+
+    return _dependency
+
+
+def _make_sync_clickhouse_dep(name: str, dev: bool = False):
+    """Return a FastAPI dependency that yields a shared sync ClickHouse client."""
+
+    def _dependency() -> Generator[Any, None, None]:
+        if name not in _CLICKHOUSE_SYNC_CLIENTS:
+            import clickhouse_connect
+
+            with runtime_flags(dev=dev, strict_translation=False):
+                config = get_database(name)
+
+            conn_kwargs = _parse_clickhouse_url(config.sqlalchemy_url)
+            client = clickhouse_connect.get_client(**conn_kwargs)
+            _CLICKHOUSE_SYNC_CLIENTS[name] = client
+
+        yield _CLICKHOUSE_SYNC_CLIENTS[name]
 
     return _dependency
 
 
 def dispose_engines() -> None:
-    """Close all cached async engines and ClickHouse clients.
+    """Close all cached engines and clients.
 
     Call during FastAPI shutdown:
 
@@ -114,5 +165,7 @@ def dispose_engines() -> None:
             yield
             dispose_engines()
     """
-    _CLICKHOUSE_CLIENTS.clear()
-    _SESSION_FACTORIES.clear()
+    _CLICKHOUSE_ASYNC_CLIENTS.clear()
+    _CLICKHOUSE_SYNC_CLIENTS.clear()
+    _ASYNC_SESSION_FACTORIES.clear()
+    _SYNC_SESSION_FACTORIES.clear()

--- a/dbwarden/fastapi/session.py
+++ b/dbwarden/fastapi/session.py
@@ -47,7 +47,8 @@ def _session_factory(database: str | None = None, dev: bool = False) -> async_se
     with runtime_flags(dev=dev, strict_translation=False):
         config = get_database(database)
     
-    cache_key, async_url = _to_async_url(config.sqlalchemy_url, config.database_type)
+    url = config.sqlalchemy_url_async or config.sqlalchemy_url
+    cache_key, async_url = _to_async_url(url, config.database_type)
     
     # Thread-safe check and create
     with _SESSION_LOCK:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -82,18 +82,18 @@ class TestConfigCommand:
         with tempfile.TemporaryDirectory() as tmpdir:
             Path(tmpdir, "dbwarden.py").write_text(
                 "from dbwarden import database_config\n\n"
-                "database_config(database_name='primary', default=True, database_type='sqlite', database_url='sqlite:///./test.db')\n",
+                "database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='sqlite:///./test.db')\n",
                 encoding="utf-8",
             )
             output = self._run_config_capture_output(tmpdir)
-            assert "database_url" in output
+            assert "database_url_sync" in output
             assert "sqlite:///./test.db" in output
 
     def test_config_masks_password(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             Path(tmpdir, "dbwarden.py").write_text(
                 "from dbwarden import database_config\n\n"
-                "database_config(database_name='primary', default=True, database_type='postgresql', database_url='postgresql://user:secretpassword@localhost/db')\n",
+                "database_config(database_name='primary', default=True, database_type='postgresql', database_url_sync='postgresql://user:secretpassword@localhost/db')\n",
                 encoding="utf-8",
             )
             output = self._run_config_capture_output(tmpdir)
@@ -105,7 +105,7 @@ class TestConfigCommand:
             Path(tmpdir, "dbwarden.py").write_text(
                 "from dbwarden import database_config\n\n"
                 "DATABASE_URL = 'postgresql://user:secretpassword@localhost/db'\n\n"
-                "database_config(database_name='primary', default=True, database_type='postgresql', database_url=DATABASE_URL, secure_values=True)\n",
+                "database_config(database_name='primary', default=True, database_type='postgresql', database_url_sync=DATABASE_URL, secure_values=True)\n",
                 encoding="utf-8",
             )
             output = self._run_config_capture_output(tmpdir)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,7 +40,7 @@ class TestConfig:
                     [
                         "from dbwarden import database_config",
                         "",
-                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url='sqlite:///./test.db')",
+                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='sqlite:///./test.db')",
                     ],
                 )
                 config = get_config()
@@ -61,7 +61,7 @@ class TestConfig:
                     [
                         "from dbwarden import database_config",
                         "",
-                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url='sqlite:///./test.db', migration_table='custom_migrations')",
+                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='sqlite:///./test.db', migration_table='custom_migrations')",
                     ],
                 )
                 config = get_config()
@@ -79,7 +79,7 @@ class TestConfig:
                     [
                         "from dbwarden import database_config",
                         "",
-                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url='sqlite:///./test.db', model_paths=['./models/user.py'])",
+                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='sqlite:///./test.db', model_paths=['./models/user.py'])",
                     ],
                 )
                 config = get_config()
@@ -87,7 +87,7 @@ class TestConfig:
             finally:
                 os.chdir(old)
 
-    def test_missing_required_field_raises_error(self):
+    def test_missing_urls_raises_error(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             old = os.getcwd()
             os.chdir(tmpdir)
@@ -97,10 +97,10 @@ class TestConfig:
                     [
                         "from dbwarden import database_config",
                         "",
-                        "database_config(database_name='primary', default=True, database_url='sqlite:///./test.db')",
+                        "database_config(database_name='primary', default=True, database_type='sqlite')",
                     ],
                 )
-                with pytest.raises(ConfigurationError, match="database_type"):
+                with pytest.raises(ConfigurationError, match="database_url_sync or database_url_async"):
                     get_config()
             finally:
                 os.chdir(old)
@@ -124,7 +124,7 @@ class TestConfig:
                     [
                         "from dbwarden import database_config",
                         "",
-                        "database_config(database_name='primary', default=False, database_type='sqlite', database_url='sqlite:///./test.db')",
+                        "database_config(database_name='primary', default=False, database_type='sqlite', database_url_sync='sqlite:///./test.db')",
                     ],
                 )
                 with pytest.raises(ConfigurationError, match="Exactly one default"):
@@ -142,8 +142,8 @@ class TestConfig:
                     [
                         "from dbwarden import database_config",
                         "",
-                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url='sqlite:///./primary.db', model_paths=['models/primary'])",
-                        "database_config(database_name='analytics', database_type='sqlite', database_url='sqlite:///./analytics.db', model_paths=['models/analytics'])",
+                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='sqlite:///./primary.db', model_paths=['models/primary'])",
+                        "database_config(database_name='analytics', database_type='sqlite', database_url_sync='sqlite:///./analytics.db', model_paths=['models/analytics'])",
                     ],
                 )
                 db = get_database("analytics")
@@ -161,7 +161,7 @@ class TestConfig:
                     [
                         "from dbwarden import database_config",
                         "",
-                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url='sqlite:///./test.db')",
+                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='sqlite:///./test.db')",
                     ],
                 )
                 with pytest.raises(ConfigurationError, match="not found in settings config"):
@@ -179,9 +179,9 @@ class TestConfig:
                     [
                         "from dbwarden import database_config",
                         "",
-                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url='sqlite:///./primary.db', model_paths=['models/primary'])",
-                        "database_config(database_name='analytics', database_type='sqlite', database_url='sqlite:///./analytics.db', model_paths=['models/analytics'])",
-                        "database_config(database_name='legacy', database_type='sqlite', database_url='sqlite:///./legacy.db', model_paths=['models/legacy'])",
+                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='sqlite:///./primary.db', model_paths=['models/primary'])",
+                        "database_config(database_name='analytics', database_type='sqlite', database_url_sync='sqlite:///./analytics.db', model_paths=['models/analytics'])",
+                        "database_config(database_name='legacy', database_type='sqlite', database_url_sync='sqlite:///./legacy.db', model_paths=['models/legacy'])",
                     ],
                 )
                 dbs = list_databases()
@@ -199,8 +199,8 @@ class TestConfig:
                     [
                         "from dbwarden import database_config",
                         "",
-                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url='sqlite:///./primary.db', model_paths=['models/primary'])",
-                        "database_config(database_name='analytics', database_type='sqlite', database_url='sqlite:///./analytics.db', model_paths=['models/analytics'])",
+                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='sqlite:///./primary.db', model_paths=['models/primary'])",
+                        "database_config(database_name='analytics', database_type='sqlite', database_url_sync='sqlite:///./analytics.db', model_paths=['models/analytics'])",
                     ],
                 )
                 config = get_multi_db_config()
@@ -220,7 +220,7 @@ class TestConfig:
                     [
                         "from dbwarden import database_config",
                         "",
-                        "database_config(database_name='primary', default=True, database_type='postgresql', database_url='postgresql://user:password@localhost:5432/main', dev_database_url='sqlite:///./development.db')",
+                        "database_config(database_name='primary', default=True, database_type='postgresql', database_url_sync='postgresql://user:password@localhost:5432/main', dev_database_url='sqlite:///./development.db')",
                     ],
                 )
                 set_dev_mode(True)
@@ -240,7 +240,7 @@ class TestConfig:
                     [
                         "from dbwarden import database_config",
                         "",
-                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url='sqlite:///./primary.db')",
+                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='sqlite:///./primary.db')",
                     ],
                 )
                 set_dev_mode(True)
@@ -259,7 +259,7 @@ class TestConfig:
                     [
                         "from dbwarden import database_config",
                         "",
-                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url='sqlite:///./primary.db', dev_database_type='sqlite')",
+                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='sqlite:///./primary.db', dev_database_type='sqlite')",
                     ],
                 )
                 with pytest.raises(ConfigurationError, match="dev_database_url is required"):
@@ -277,11 +277,11 @@ class TestConfig:
                     [
                         "from dbwarden import database_config",
                         "",
-                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url='sqlite:///./same.db', model_paths=['models/primary'])",
-                        "database_config(database_name='analytics', database_type='sqlite', database_url='sqlite:///./same.db', model_paths=['models/analytics'])",
+                        "database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='sqlite:///./same.db', model_paths=['models/primary'])",
+                        "database_config(database_name='analytics', database_type='sqlite', database_url_sync='sqlite:///./same.db', model_paths=['models/analytics'])",
                     ],
                 )
-                with pytest.raises(ConfigurationError, match="Duplicate database_url"):
+                with pytest.raises(ConfigurationError, match="Duplicate database_url_sync"):
                     get_multi_db_config()
             finally:
                 os.chdir(old)

--- a/tests/test_config_alt.py
+++ b/tests/test_config_alt.py
@@ -32,7 +32,7 @@ class TestConfigAlt:
                 _write_settings(
                     Path("dbwarden.py"),
                     "from dbwarden import database_config\n\n"
-                    "database_config(database_name='primary', default=True, database_type='sqlite', database_url='sqlite:///./app.db')\n",
+                    "database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='sqlite:///./app.db')\n",
                 )
 
                 cfg = get_multi_db_config()
@@ -50,8 +50,8 @@ class TestConfigAlt:
                 _write_settings(
                     Path("dbwarden.py"),
                     "from dbwarden import database_config\n\n"
-                    "database_config(database_name='primary', default=True, database_type='sqlite', database_url='sqlite:///./app.db')\n"
-                    "database_config(database_name='analytics', database_type='sqlite', database_url='sqlite:///./analytics.db')\n",
+                    "database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='sqlite:///./app.db')\n"
+                    "database_config(database_name='analytics', database_type='sqlite', database_url_sync='sqlite:///./analytics.db')\n",
                 )
 
                 with pytest.raises(ConfigurationError, match="model_paths is required"):
@@ -67,8 +67,8 @@ class TestConfigAlt:
                 _write_settings(
                     Path("dbwarden.py"),
                     "from dbwarden import database_config\n\n"
-                    "database_config(database_name='primary', default=True, database_type='sqlite', database_url='sqlite:///./app.db', model_paths=['models/shared'])\n"
-                    "database_config(database_name='analytics', database_type='sqlite', database_url='sqlite:///./analytics.db', model_paths=['models/shared'])\n",
+                    "database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='sqlite:///./app.db', model_paths=['models/shared'])\n"
+                    "database_config(database_name='analytics', database_type='sqlite', database_url_sync='sqlite:///./analytics.db', model_paths=['models/shared'])\n",
                 )
 
                 with pytest.raises(ConfigurationError, match="model_paths overlap"):
@@ -84,7 +84,7 @@ class TestConfigAlt:
                 _write_settings(
                     Path("dbwarden.py"),
                     "from dbwarden import database_config\n\n"
-                    "database_config(database_name='primary', default=True, database_type='postgresql', database_url='postgresql://user:pass@localhost:5432/main', dev_database_type='sqlite', dev_database_url='sqlite:///./dev.db')\n",
+                    "database_config(database_name='primary', default=True, database_type='postgresql', database_url_sync='postgresql://user:pass@localhost:5432/main', dev_database_type='sqlite', dev_database_url='sqlite:///./dev.db')\n",
                 )
 
                 set_dev_mode(True)
@@ -115,12 +115,12 @@ class TestConfigAlt:
                     Path("dbwarden.py"),
                     "from dbwarden import database_config\n\n"
                     "DATABASE_URL = 'postgresql://user:pass@localhost/db'\n"
-                    "database_config(database_name='primary', default=True, database_type='postgresql', database_url=DATABASE_URL, secure_values=True)\n",
+                    "database_config(database_name='primary', default=True, database_type='postgresql', database_url_sync=DATABASE_URL, secure_values=True)\n",
                 )
 
                 cfg = get_multi_db_config()
                 assert cfg.databases["primary"].secure_values is True
-                assert cfg.databases["primary"].secure_display_values["database_url"] == "DATABASE_URL"
+                assert cfg.databases["primary"].secure_display_values["database_url_sync"] == "DATABASE_URL"
                 assert cfg.databases["primary"].sqlalchemy_url == "postgresql://user:pass@localhost/db"
             finally:
                 os.chdir(old_cwd)

--- a/tests/test_fastapi_async_db.py
+++ b/tests/test_fastapi_async_db.py
@@ -18,30 +18,30 @@ def _is_depends_instance(obj) -> bool:
 class TestDatabaseHandle:
     """Tests for the DatabaseHandle returned by database_config()."""
 
-    def test_session_property_returns_annotated_sql(self):
+    def test_async_session_property_returns_annotated_sql(self):
         from dbwarden.db_handle import DatabaseHandle
 
         handle = DatabaseHandle("primary", "postgresql")
-        ann = handle.session
+        ann = handle.async_session
 
         assert get_origin(ann) is Annotated
         assert AsyncSession in ann.__args__
         assert any(_is_depends_instance(a) for a in ann.__metadata__)
 
-    def test_session_property_returns_annotated_sqlite(self):
+    def test_async_session_property_returns_annotated_sqlite(self):
         from dbwarden.db_handle import DatabaseHandle
 
         handle = DatabaseHandle("analytics", "sqlite")
-        ann = handle.session
+        ann = handle.async_session
 
         assert get_origin(ann) is Annotated
         assert AsyncSession in ann.__args__
 
-    def test_session_property_returns_annotated_clickhouse(self):
+    def test_async_session_property_returns_annotated_clickhouse(self):
         from dbwarden.db_handle import DatabaseHandle
 
         handle = DatabaseHandle("analytics", "clickhouse")
-        ann = handle.session
+        ann = handle.async_session
 
         from clickhouse_connect.driver.asyncclient import AsyncClient
 
@@ -49,18 +49,42 @@ class TestDatabaseHandle:
         assert AsyncClient in ann.__args__
         assert any(_is_depends_instance(a) for a in ann.__metadata__)
 
-    def test_session_property_raises_for_unknown_type(self):
+    def test_async_session_property_raises_for_unknown_type(self):
         from dbwarden.db_handle import DatabaseHandle
 
         handle = DatabaseHandle("bad", "mongodb")
         with pytest.raises(ValueError, match="Unsupported database_type"):
-            _ = handle.session
+            _ = handle.async_session
 
-    def test_session_property_cached(self):
+    def test_async_session_property_cached(self):
         from dbwarden.db_handle import DatabaseHandle
 
         handle = DatabaseHandle("primary", "postgresql")
-        assert handle.session is handle.session
+        assert handle.async_session is handle.async_session
+
+    def test_sync_session_property_returns_annotated(self):
+        from dbwarden.db_handle import DatabaseHandle
+        from sqlalchemy.orm import Session
+
+        handle = DatabaseHandle("primary", "postgresql")
+        ann = handle.sync_session
+
+        assert get_origin(ann) is Annotated
+        assert Session in ann.__args__
+        assert any(_is_depends_instance(a) for a in ann.__metadata__)
+
+    def test_sync_session_property_raises_for_unknown_type(self):
+        from dbwarden.db_handle import DatabaseHandle
+
+        handle = DatabaseHandle("bad", "mongodb")
+        with pytest.raises(ValueError, match="Unsupported database_type"):
+            _ = handle.sync_session
+
+    def test_sync_session_property_cached(self):
+        from dbwarden.db_handle import DatabaseHandle
+
+        handle = DatabaseHandle("primary", "postgresql")
+        assert handle.sync_session is handle.sync_session
 
     def test_database_config_returns_handle(self):
         import dbwarden.config_registry as cr
@@ -68,19 +92,20 @@ class TestDatabaseHandle:
         handle = cr.database_config(
             database_name="test_handle",
             database_type="sqlite",
-            database_url="sqlite:///./test.db",
+            database_url_sync="sqlite:///./test.db",
         )
         from dbwarden.db_handle import DatabaseHandle
 
         assert isinstance(handle, DatabaseHandle)
-        assert hasattr(handle, "session")
+        assert hasattr(handle, "async_session")
+        assert hasattr(handle, "sync_session")
 
 
 class TestMakeSessionDep:
     """Tests for _make_session_dep factory."""
 
     def test_returns_callable(self):
-        from dbwarden.fastapi.async_db import _make_session_dep
+        from dbwarden.fastapi.engines import _make_session_dep
 
         dep = _make_session_dep("primary")
         assert callable(dep)
@@ -88,19 +113,21 @@ class TestMakeSessionDep:
     def test_dependency_is_async_generator_function(self, monkeypatch):
         mock_db = type("MockDB", (), {
             "database_type": "sqlite",
+            "sqlalchemy_url_sync": "sqlite:///:memory:",
+            "sqlalchemy_url_async": None,
             "sqlalchemy_url": "sqlite:///:memory:",
         })()
 
         def mock_get_database(name=None):
             return mock_db
 
-        monkeypatch.setattr("dbwarden.fastapi.async_db.get_database", mock_get_database)
-        monkeypatch.setattr("dbwarden.fastapi.async_db.runtime_flags", lambda dev, strict_translation: type("ctx", (), {
+        monkeypatch.setattr("dbwarden.fastapi.engines.get_database", mock_get_database)
+        monkeypatch.setattr("dbwarden.fastapi.engines.runtime_flags", lambda dev, strict_translation: type("ctx", (), {
             "__enter__": lambda s: None,
             "__exit__": lambda s, *a: None,
         })())
 
-        from dbwarden.fastapi.async_db import _make_session_dep
+        from dbwarden.fastapi.engines import _make_session_dep
 
         dep = _make_session_dep("primary")
         import inspect
@@ -108,7 +135,7 @@ class TestMakeSessionDep:
         assert inspect.isasyncgenfunction(dep)
 
     def test_session_dep_works_with_annotation(self):
-        from dbwarden.fastapi.async_db import _make_session_dep
+        from dbwarden.fastapi.engines import _make_session_dep
 
         dep = _make_session_dep("primary")
 
@@ -123,13 +150,13 @@ class TestMakeClickHouseDep:
     """Tests for _make_clickhouse_dep factory."""
 
     def test_returns_callable(self):
-        from dbwarden.fastapi.async_db import _make_clickhouse_dep
+        from dbwarden.fastapi.engines import _make_clickhouse_dep
 
         dep = _make_clickhouse_dep("analytics")
         assert callable(dep)
 
     def test_dependency_is_async_generator_function(self):
-        from dbwarden.fastapi.async_db import _make_clickhouse_dep
+        from dbwarden.fastapi.engines import _make_clickhouse_dep
 
         dep = _make_clickhouse_dep("analytics")
         import inspect
@@ -137,7 +164,7 @@ class TestMakeClickHouseDep:
         assert inspect.isasyncgenfunction(dep)
 
     def test_clickhouse_dep_works_with_annotation(self):
-        from dbwarden.fastapi.async_db import _make_clickhouse_dep
+        from dbwarden.fastapi.engines import _make_clickhouse_dep
 
         dep = _make_clickhouse_dep("analytics")
         from clickhouse_connect.driver.asyncclient import AsyncClient
@@ -153,12 +180,12 @@ class TestDisposeEngines:
     """Tests for dispose_engines cleanup."""
 
     def test_dispose_engines_clears_caches(self):
-        from dbwarden.fastapi import async_db
+        from dbwarden.fastapi import engines
 
-        async_db._SESSION_FACTORIES["test"] = "fake"
-        async_db._CLICKHOUSE_CLIENTS["test"] = "fake"
+        engines._ASYNC_SESSION_FACTORIES["test"] = "fake"
+        engines._CLICKHOUSE_ASYNC_CLIENTS["test"] = "fake"
 
-        async_db.dispose_engines()
+        engines.dispose_engines()
 
-        assert "test" not in async_db._SESSION_FACTORIES
-        assert "test" not in async_db._CLICKHOUSE_CLIENTS
+        assert "test" not in engines._ASYNC_SESSION_FACTORIES
+        assert "test" not in engines._CLICKHOUSE_ASYNC_CLIENTS

--- a/tests/test_fastapi_async_db.py
+++ b/tests/test_fastapi_async_db.py
@@ -1,0 +1,164 @@
+"""Tests for async database engine dependencies and DatabaseHandle."""
+
+from typing import Annotated, get_origin
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi import Depends
+from fastapi.params import Depends as DependsCls
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def _is_depends_instance(obj) -> bool:
+    """Check if *obj* is a FastAPI Depends() instance."""
+    return type(obj).__name__ == "Depends" or hasattr(obj, "dependency")
+
+
+class TestDatabaseHandle:
+    """Tests for the DatabaseHandle returned by database_config()."""
+
+    def test_session_property_returns_annotated_sql(self):
+        from dbwarden.db_handle import DatabaseHandle
+
+        handle = DatabaseHandle("primary", "postgresql")
+        ann = handle.session
+
+        assert get_origin(ann) is Annotated
+        assert AsyncSession in ann.__args__
+        assert any(_is_depends_instance(a) for a in ann.__metadata__)
+
+    def test_session_property_returns_annotated_sqlite(self):
+        from dbwarden.db_handle import DatabaseHandle
+
+        handle = DatabaseHandle("analytics", "sqlite")
+        ann = handle.session
+
+        assert get_origin(ann) is Annotated
+        assert AsyncSession in ann.__args__
+
+    def test_session_property_returns_annotated_clickhouse(self):
+        from dbwarden.db_handle import DatabaseHandle
+
+        handle = DatabaseHandle("analytics", "clickhouse")
+        ann = handle.session
+
+        from clickhouse_connect.driver.asyncclient import AsyncClient
+
+        assert get_origin(ann) is Annotated
+        assert AsyncClient in ann.__args__
+        assert any(_is_depends_instance(a) for a in ann.__metadata__)
+
+    def test_session_property_raises_for_unknown_type(self):
+        from dbwarden.db_handle import DatabaseHandle
+
+        handle = DatabaseHandle("bad", "mongodb")
+        with pytest.raises(ValueError, match="Unsupported database_type"):
+            _ = handle.session
+
+    def test_session_property_cached(self):
+        from dbwarden.db_handle import DatabaseHandle
+
+        handle = DatabaseHandle("primary", "postgresql")
+        assert handle.session is handle.session
+
+    def test_database_config_returns_handle(self):
+        import dbwarden.config_registry as cr
+
+        handle = cr.database_config(
+            database_name="test_handle",
+            database_type="sqlite",
+            database_url="sqlite:///./test.db",
+        )
+        from dbwarden.db_handle import DatabaseHandle
+
+        assert isinstance(handle, DatabaseHandle)
+        assert hasattr(handle, "session")
+
+
+class TestMakeSessionDep:
+    """Tests for _make_session_dep factory."""
+
+    def test_returns_callable(self):
+        from dbwarden.fastapi.async_db import _make_session_dep
+
+        dep = _make_session_dep("primary")
+        assert callable(dep)
+
+    def test_dependency_is_async_generator_function(self, monkeypatch):
+        mock_db = type("MockDB", (), {
+            "database_type": "sqlite",
+            "sqlalchemy_url": "sqlite:///:memory:",
+        })()
+
+        def mock_get_database(name=None):
+            return mock_db
+
+        monkeypatch.setattr("dbwarden.fastapi.async_db.get_database", mock_get_database)
+        monkeypatch.setattr("dbwarden.fastapi.async_db.runtime_flags", lambda dev, strict_translation: type("ctx", (), {
+            "__enter__": lambda s: None,
+            "__exit__": lambda s, *a: None,
+        })())
+
+        from dbwarden.fastapi.async_db import _make_session_dep
+
+        dep = _make_session_dep("primary")
+        import inspect
+
+        assert inspect.isasyncgenfunction(dep)
+
+    def test_session_dep_works_with_annotation(self):
+        from dbwarden.fastapi.async_db import _make_session_dep
+
+        dep = _make_session_dep("primary")
+
+        ann = Annotated[AsyncSession, Depends(dep)]
+
+        assert get_origin(ann) is Annotated
+        assert AsyncSession in ann.__args__
+        assert any(_is_depends_instance(a) for a in ann.__metadata__)
+
+
+class TestMakeClickHouseDep:
+    """Tests for _make_clickhouse_dep factory."""
+
+    def test_returns_callable(self):
+        from dbwarden.fastapi.async_db import _make_clickhouse_dep
+
+        dep = _make_clickhouse_dep("analytics")
+        assert callable(dep)
+
+    def test_dependency_is_async_generator_function(self):
+        from dbwarden.fastapi.async_db import _make_clickhouse_dep
+
+        dep = _make_clickhouse_dep("analytics")
+        import inspect
+
+        assert inspect.isasyncgenfunction(dep)
+
+    def test_clickhouse_dep_works_with_annotation(self):
+        from dbwarden.fastapi.async_db import _make_clickhouse_dep
+
+        dep = _make_clickhouse_dep("analytics")
+        from clickhouse_connect.driver.asyncclient import AsyncClient
+
+        ann = Annotated[AsyncClient, Depends(dep)]
+
+        assert get_origin(ann) is Annotated
+        assert AsyncClient in ann.__args__
+        assert any(_is_depends_instance(a) for a in ann.__metadata__)
+
+
+class TestDisposeEngines:
+    """Tests for dispose_engines cleanup."""
+
+    def test_dispose_engines_clears_caches(self):
+        from dbwarden.fastapi import async_db
+
+        async_db._SESSION_FACTORIES["test"] = "fake"
+        async_db._CLICKHOUSE_CLIENTS["test"] = "fake"
+
+        async_db.dispose_engines()
+
+        assert "test" not in async_db._SESSION_FACTORIES
+        assert "test" not in async_db._CLICKHOUSE_CLIENTS

--- a/tests/test_fastapi_edge_cases.py
+++ b/tests/test_fastapi_edge_cases.py
@@ -226,7 +226,7 @@ class TestMigrationContextEdgeCases:
         mock_db.database_name = "primary"
         mock_db.database_type = "sqlite"
         mock_db.sqlalchemy_url = "sqlite:///:memory:"
-        mock_db.dev_sqlalchemy_url = None
+        mock_db.sqlalchemy_url_sync = "sqlite:///:memory:"
         mock_db.model_paths = None
 
         def mock_get_database(name=None):
@@ -280,7 +280,7 @@ class TestGetSessionEdgeCases:
         mock_db.database_name = "primary"
         mock_db.database_type = "sqlite"
         mock_db.sqlalchemy_url = "sqlite:///:memory:"
-        mock_db.dev_sqlalchemy_url = None
+        mock_db.sqlalchemy_url_sync = "sqlite:///:memory:"
 
         def mock_get_database(name=None):
             return mock_db
@@ -309,7 +309,7 @@ class TestGetSessionEdgeCases:
         mock_db.database_name = "primary"
         mock_db.database_type = "sqlite"
         mock_db.sqlalchemy_url = "sqlite:///:memory:"
-        mock_db.dev_sqlalchemy_url = None
+        mock_db.sqlalchemy_url_sync = "sqlite:///:memory:"
 
         def mock_get_database(name=None):
             return mock_db

--- a/tests/test_fastapi_session.py
+++ b/tests/test_fastapi_session.py
@@ -49,7 +49,8 @@ class TestGetSession:
         mock_db.database_name = "primary"
         mock_db.database_type = "sqlite"
         mock_db.sqlalchemy_url = "sqlite:///:memory:"
-        mock_db.dev_sqlalchemy_url = None
+        mock_db.sqlalchemy_url_sync = "sqlite:///:memory:"
+        mock_db.sqlalchemy_url_async = None
 
         mock_multi = MagicMock()
         mock_multi.databases = {"primary": mock_db}
@@ -128,6 +129,8 @@ class TestGetSessionErrors:
         mock_db.database_name = "primary"
         mock_db.database_type = "unsupported"
         mock_db.sqlalchemy_url = "unsupported://localhost/db"
+        mock_db.sqlalchemy_url_sync = "unsupported://localhost/db"
+        mock_db.sqlalchemy_url_async = None
 
         def mock_get_database(name=None):
             return mock_db

--- a/tests/test_make_migrations.py
+++ b/tests/test_make_migrations.py
@@ -111,7 +111,7 @@ def test_make_migrations_writes_plan_file_next_to_sql():
         try:
             Path("dbwarden.py").write_text(
                 "from dbwarden import database_config\n\n"
-                "database_config(database_name='primary', default=True, database_type='sqlite', database_url='sqlite:///./app.db', model_paths=['models'])\n",
+                "database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='sqlite:///./app.db', model_paths=['models'])\n",
                 encoding="utf-8",
             )
             Path("migrations/primary").mkdir(parents=True)

--- a/tests/test_settings_commands.py
+++ b/tests/test_settings_commands.py
@@ -20,7 +20,7 @@ def _write_settings(path: Path) -> None:
         "    database_name='primary',\n"
         "    default=True,\n"
         "    database_type='sqlite',\n"
-        "    database_url='sqlite:///./app.db',\n"
+        "    database_url_sync='sqlite:///./app.db',\n"
         "    model_paths=['models/primary'],\n"
         ")\n",
         encoding="utf-8",

--- a/tests/test_sql_integration.py
+++ b/tests/test_sql_integration.py
@@ -65,7 +65,7 @@ class TestDatabaseOperations:
                     "    database_name='primary',\n"
                     "    default=True,\n"
                     "    database_type='sqlite',\n"
-                    f"    database_url='sqlite:///{temp_db}',\n"
+                    f"    database_url_sync='sqlite:///{temp_db}',\n"
                     ")\n"
                 )
 


### PR DESCRIPTION
### Breaking
- `database_config()` now takes `database_url_sync` / `database_url_async`
  instead of `database_url` — explicit typed kwargs for IDE autocomplete

### New
- `DatabaseHandle.async_session`: FastAPI dependency for async SQL/ClickHouse
- `DatabaseHandle.sync_session`: FastAPI dependency for sync SQL/ClickHouse
- `dbwarden/fastapi/engines.py`: unified engine module with sync + async
  session factories for both SQL and ClickHouse
- `database_config()` returns `DatabaseHandle` directly

### Internal
- `DatabaseEntry` / `DatabaseConfig`: separate sync/async URL fields
  with backward-compat `sqlalchemy_url` property
- Separate caches for sync/async ClickHouse clients
- Validation: at least one URL required