### PR TITLE
feat(snapshot): schema snapshots for rename detection

### DIFF
--- a/dbwarden/cli/main.py
+++ b/dbwarden/cli/main.py
@@ -11,6 +11,7 @@ from dbwarden.commands import (
     handle_database_remove,
     handle_diff,
     handle_downgrade,
+    handle_generate_models,
     handle_history,
     handle_init,
     handle_lock_status,
@@ -223,6 +224,47 @@ def settings_database_clear_dev(
 ):
     """Clear development database settings."""
     handle_settings_database_clear_dev_command(name)
+
+
+@app.command()
+def generate_models(
+    output: str = typer.Option(
+        "models", "--output", "-o", help="Output directory for generated model files"
+    ),
+    tables: str | None = typer.Option(
+        None, "--tables", help="Comma-separated list of tables to include"
+    ),
+    exclude_tables: str | None = typer.Option(
+        None, "--exclude-tables", help="Comma-separated list of tables to exclude"
+    ),
+    clickhouse_engines: bool = typer.Option(
+        False, "--clickhouse-engines", help="Include ClickHouse engine metadata"
+    ),
+    relationships: bool = typer.Option(
+        False, "--relationships", help="Generate relationship attributes"
+    ),
+    dialect: str | None = typer.Option(
+        None, "--dialect", help="SQL dialect for type mapping (auto-detected by default)"
+    ),
+    single_file: bool = typer.Option(
+        False, "--single-file", help="Generate a single models.py file"
+    ),
+    database: str | None = typer.Option(
+        None, "--database", "-d", help="Target database name"
+    ),
+):
+    """Reverse-engineer SQLAlchemy model code from a live database."""
+    validate_directory()
+    handle_generate_models(
+        output=output,
+        tables=tables,
+        exclude_tables=exclude_tables,
+        clickhouse_engines=clickhouse_engines,
+        relationships=relationships,
+        dialect=dialect,
+        single_file=single_file,
+        database=database,
+    )
 
 
 @app.command()

--- a/dbwarden/cli/main.py
+++ b/dbwarden/cli/main.py
@@ -10,10 +10,12 @@ from dbwarden.commands import (
     handle_database_list,
     handle_database_remove,
     handle_diff,
+    handle_downgrade,
     handle_history,
     handle_init,
     handle_lock_status,
     handle_make_migrations,
+    handle_make_rollback,
     handle_migrate,
     handle_new,
     handle_rollback,
@@ -21,6 +23,7 @@ from dbwarden.commands import (
     handle_seed_create,
     handle_seed_list,
     handle_seed_rollback,
+    handle_snapshot,
     handle_squash,
     handle_status,
     handle_unlock,
@@ -331,6 +334,45 @@ def rollback(
     handle_rollback(
         count=count, to_version=to_version, verbose=verbose, database=database
     )
+
+
+@app.command()
+def downgrade(
+    to_version: str = typer.Option(
+        ..., "--to", "-t", help="Target version to downgrade to"
+    ),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Enable verbose logging"
+    ),
+    database: str | None = typer.Option(
+        None, "--database", "-d", help="Target database name"
+    ),
+):
+    """Downgrade to a specific migration version by reverting applied migrations."""
+    validate_directory()
+    handle_downgrade(to_version=to_version, verbose=verbose, database=database)
+
+
+@app.command()
+def make_rollback(
+    migration_file: str = typer.Argument(
+        ..., help="Path to migration SQL file"
+    ),
+):
+    """Generate a rollback SQL file for a given migration file."""
+    handle_make_rollback(migration_file=migration_file)
+
+
+@app.command()
+def snapshot(
+    table_name: str = typer.Argument(..., help="Table name to snapshot"),
+    database: str | None = typer.Option(
+        None, "--database", "-d", help="Target database name"
+    ),
+):
+    """Snapshot the DDL schema of a specific table."""
+    validate_directory()
+    handle_snapshot(table_name=table_name, database=database)
 
 
 @app.command()

--- a/dbwarden/commands/__init__.py
+++ b/dbwarden/commands/__init__.py
@@ -1,11 +1,14 @@
 from dbwarden.commands.check import check_cmd
 from dbwarden.commands.check_db import check_db_cmd
+from dbwarden.commands.downgrade import downgrade_cmd
 from dbwarden.commands.extra import diff_cmd, lock_status_cmd, squash_cmd, unlock_cmd
 from dbwarden.commands.history import history_cmd
 from dbwarden.commands.init import init_cmd
 from dbwarden.commands.make_migrations import make_migrations_cmd, new_migration_cmd
+from dbwarden.commands.make_rollback import make_rollback_cmd
 from dbwarden.commands.migrate import migrate_cmd
 from dbwarden.commands.rollback import rollback_cmd
+from dbwarden.commands.snapshot import snapshot_cmd
 from dbwarden.commands.seeds import (
     seed_apply_cmd,
     seed_create_cmd,
@@ -236,6 +239,27 @@ def handle_settings_database_set_dev_command(
 
 def handle_settings_database_clear_dev_command(name: str) -> None:
     handle_settings_database_clear_dev(name)
+
+
+def handle_downgrade(
+    to_version: str,
+    verbose: bool = False,
+    database: str | None = None,
+) -> None:
+    downgrade_cmd(to_version=to_version, verbose=verbose, database=database)
+
+
+def handle_make_rollback(
+    migration_file: str,
+) -> None:
+    make_rollback_cmd(migration_file=migration_file)
+
+
+def handle_snapshot(
+    table_name: str,
+    database: str | None = None,
+) -> None:
+    snapshot_cmd(table_name=table_name, database=database)
 
 
 def handle_seed_create(

--- a/dbwarden/commands/__init__.py
+++ b/dbwarden/commands/__init__.py
@@ -2,6 +2,7 @@ from dbwarden.commands.check import check_cmd
 from dbwarden.commands.check_db import check_db_cmd
 from dbwarden.commands.downgrade import downgrade_cmd
 from dbwarden.commands.extra import diff_cmd, lock_status_cmd, squash_cmd, unlock_cmd
+from dbwarden.commands.generate_models import generate_models_cmd
 from dbwarden.commands.history import history_cmd
 from dbwarden.commands.init import init_cmd
 from dbwarden.commands.make_migrations import make_migrations_cmd, new_migration_cmd
@@ -260,6 +261,28 @@ def handle_snapshot(
     database: str | None = None,
 ) -> None:
     snapshot_cmd(table_name=table_name, database=database)
+
+
+def handle_generate_models(
+    output: str = "models",
+    tables: str | None = None,
+    exclude_tables: str | None = None,
+    clickhouse_engines: bool = False,
+    relationships: bool = False,
+    dialect: str | None = None,
+    single_file: bool = False,
+    database: str | None = None,
+) -> None:
+    generate_models_cmd(
+        output=output,
+        tables=tables,
+        exclude_tables=exclude_tables,
+        clickhouse_engines=clickhouse_engines,
+        relationships=relationships,
+        dialect=dialect,
+        single_file=single_file,
+        database=database,
+    )
 
 
 def handle_seed_create(

--- a/dbwarden/commands/downgrade.py
+++ b/dbwarden/commands/downgrade.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import time
+
+from dbwarden.config import get_database
+from dbwarden.engine.file_parser import parse_rollback_statements
+from dbwarden.engine.version import get_migration_filepaths_by_version, get_migrations_directory
+from dbwarden.logging import get_logger
+from dbwarden.output import console
+from dbwarden.repositories import (
+    create_lock_table_if_not_exists,
+    create_migrations_table_if_not_exists,
+    get_migrated_versions,
+    run_migration,
+)
+
+
+def downgrade_cmd(
+    to_version: str,
+    verbose: bool = False,
+    database: str | None = None,
+) -> None:
+    config = get_database(database)
+    actual_db_name = database or config.sqlalchemy_url.split("/")[-1].split("?")[0]
+    logger = get_logger(
+        verbose=verbose, db_name=actual_db_name, db_type=config.database_type
+    )
+
+    migrations_dir = get_migrations_directory(database)
+
+    create_migrations_table_if_not_exists(database)
+    create_lock_table_if_not_exists(database)
+
+    applied_versions = get_migrated_versions(database)
+    if not applied_versions:
+        console.print("Nothing to downgrade.", style="cyan")
+        return
+
+    if to_version not in applied_versions:
+        console.print(
+            f"Target version {to_version} has not been applied. Cannot downgrade.",
+            style="red",
+        )
+        return
+
+    versions_to_revert = [v for v in applied_versions if v > to_version]
+    if not versions_to_revert:
+        console.print(f"Already at version {to_version}. Nothing to downgrade.", style="cyan")
+        return
+
+    filepaths = get_migration_filepaths_by_version(
+        directory=migrations_dir,
+        version_to_start_from=to_version,
+        end_version=versions_to_revert[-1],
+    )
+
+    reverted = []
+    for version in reversed(versions_to_revert):
+        if version not in filepaths:
+            console.print(
+                f"Migration file for version {version} not found.", style="red"
+            )
+            continue
+
+        filepath = filepaths[version]
+        filename = filepath.split("/")[-1]
+        sql_statements = parse_rollback_statements(filepath)
+
+        if not sql_statements:
+            logger.info(f"No rollback statements found for {filename}, skipping.")
+            continue
+
+        for sql in sql_statements:
+            logger.log_sql_statement(sql)
+
+        start_time = time.time()
+        logger.info(f"Downgrading migration: {filename} (version: {version})")
+
+        run_migration(
+            sql_statements=sql_statements,
+            version=version,
+            migration_operation="rollback",
+            filename=filename,
+            db_name=database,
+        )
+
+        duration = time.time() - start_time
+        logger.info(f"Downgrade completed: {filename} in {duration:.2f}s")
+        reverted.append(version)
+
+    if reverted:
+        console.print(
+            f"Downgrade completed: {len(reverted)} migration(s) reverted to version {to_version}.",
+            style="green",
+        )
+    else:
+        console.print("No migrations were downgraded.", style="yellow")

--- a/dbwarden/commands/generate_models.py
+++ b/dbwarden/commands/generate_models.py
@@ -1,0 +1,594 @@
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from dbwarden.config import get_database
+from dbwarden.database.connection import get_db_connection
+from dbwarden.output import console
+
+
+_TYPE_MAP: dict[str, str] = {
+    "INTEGER": "Integer",
+    "BIGINT": "BigInteger",
+    "SMALLINT": "SmallInteger",
+    "VARCHAR": "String",
+    "CHAR": "String",
+    "TEXT": "Text",
+    "BOOLEAN": "Boolean",
+    "FLOAT": "Float",
+    "REAL": "Float",
+    "DOUBLE": "Float",
+    "DECIMAL": "Numeric",
+    "NUMERIC": "Numeric",
+    "DATE": "Date",
+    "DATETIME": "DateTime",
+    "TIMESTAMP": "DateTime",
+    "TIME": "Time",
+    "BLOB": "LargeBinary",
+    "BYTEA": "LargeBinary",
+    "BINARY": "LargeBinary",
+    "JSON": "JSON",
+    "UUID": "String(36)",
+    "ENUM": "Enum",
+    "SERIAL": "Integer",
+    "BIGSERIAL": "BigInteger",
+    "TINYINT": "SmallInteger",
+}
+
+
+_CLICKHOUSE_MAP: dict[str, str] = {
+    "Int8": "SmallInteger",
+    "Int16": "SmallInteger",
+    "Int32": "Integer",
+    "Int64": "BigInteger",
+    "UInt8": "SmallInteger",
+    "UInt16": "Integer",
+    "UInt32": "BigInteger",
+    "UInt64": "BigInteger",
+    "Float32": "Float",
+    "Float64": "Float",
+    "String": "String",
+    "FixedString": "String",
+    "Date": "Date",
+    "DateTime": "DateTime",
+    "DateTime64": "DateTime",
+    "UUID": "String(36)",
+    "JSON": "JSON",
+}
+
+
+def _parse_type(raw: str, dialect: str | None = None) -> str:
+    raw_stripped = raw.strip()
+    upper = raw_stripped.upper()
+
+    is_nullable = upper.startswith("NULLABLE(")
+    if is_nullable:
+        inner = raw_stripped[9:-1].strip()
+        inner_type = _parse_type(inner, dialect)
+        return inner_type
+
+    if upper.startswith("LOWCARDINALITY("):
+        inner = raw_stripped[15:-1].strip()
+        return _parse_type(inner, dialect)
+
+    if upper.startswith("ARRAY("):
+        inner = raw_stripped[6:-1].strip()
+        inner_type = _parse_type(inner, dialect)
+        return f"ARRAY({inner_type})"
+
+    if upper.startswith("MAP("):
+        return "JSON"
+
+    if upper.startswith("ENUM"):
+        return "Enum"
+
+    if upper.startswith("DECIMAL") or upper.startswith("NUMERIC"):
+        match = re.match(r"(DECIMAL|NUMERIC)\((\d+),\s*(\d+)\)", raw_stripped, re.IGNORECASE)
+        if match:
+            return f"Numeric(precision={match.group(2)}, scale={match.group(3)})"
+        return "Numeric"
+
+    if upper.startswith("VARCHAR"):
+        match = re.match(r"VARCHAR\((\d+)\)", raw_stripped, re.IGNORECASE)
+        if match:
+            return f"String(length={match.group(1)})"
+        return "String"
+
+    if upper.startswith("CHAR"):
+        match = re.match(r"CHAR\((\d+)\)", raw_stripped, re.IGNORECASE)
+        if match:
+            return f"String(length={match.group(1)})"
+        return "String"
+
+    if upper.startswith("FLOAT"):
+        return "Float"
+
+    if upper.startswith("DOUBLE"):
+        return "Float"
+
+    if upper.startswith("DATETIME"):
+        return "DateTime"
+
+    if upper.startswith("TIMESTAMP"):
+        return "DateTime"
+
+    if upper.startswith("TINYINT"):
+        if upper == "TINYINT(1)":
+            return "Boolean"
+        return "SmallInteger"
+
+    if upper.startswith("BIGINT"):
+        return "BigInteger"
+
+    if upper.startswith("SMALLINT"):
+        return "SmallInteger"
+
+    if upper.startswith("SERIAL"):
+        return "Integer"
+
+    if upper.startswith("BIGSERIAL"):
+        return "BigInteger"
+
+    if dialect and dialect == "clickhouse":
+        for ch_key, ch_val in _CLICKHOUSE_MAP.items():
+            if raw_stripped.upper().startswith(ch_key.upper()):
+                return ch_val
+
+    for t_key, t_val in _TYPE_MAP.items():
+        if upper.startswith(t_key):
+            return t_val
+
+    if upper.startswith("INT"):
+        return "Integer"
+
+    return "String"
+
+
+def _format_default(default: Any) -> str | None:
+    if default is None:
+        return None
+    raw = str(default).strip().strip("'\"")
+    if not raw:
+        return None
+    upper = raw.upper()
+    if upper == "NULL":
+        return None
+    if upper == "CURRENT_TIMESTAMP":
+        return "func.now()"
+    if upper == "CURRENT_DATE":
+        return "func.current_date()"
+    if upper == "CURRENT_TIME":
+        return "func.current_time()"
+    if upper in ("TRUE", "FALSE", "1", "0"):
+        return raw
+    if re.match(r"^\d+(\.\d+)?$", raw):
+        return raw
+    return repr(raw)
+
+
+def _resolve_imports(columns: list[dict], has_relationships: bool) -> set[str]:
+    imports: set[str] = {"Column"}
+    for col in columns:
+        sa_type = _parse_type(col["type"], col.get("dialect"))
+        base_type = sa_type.split("(")[0].strip().upper()
+        if base_type in ("STRING", "TEXT"):
+            imports.add("String")
+            imports.add("Text")
+        elif base_type == "INTEGER":
+            imports.add("Integer")
+        elif base_type == "BIGINTEGER":
+            imports.add("BigInteger")
+        elif base_type == "SMALLINTEGER":
+            imports.add("SmallInteger")
+        elif base_type == "BOOLEAN":
+            imports.add("Boolean")
+        elif base_type == "FLOAT":
+            imports.add("Float")
+        elif base_type == "NUMERIC":
+            imports.add("Numeric")
+        elif base_type == "DATETIME":
+            imports.add("DateTime")
+        elif base_type == "DATE":
+            imports.add("Date")
+        elif base_type == "TIME":
+            imports.add("Time")
+        elif base_type == "LARGEBINARY":
+            imports.add("LargeBinary")
+        elif base_type == "JSON":
+            imports.add("JSON")
+        elif base_type == "ENUM":
+            imports.add("Enum")
+        if col.get("default") and "func.now()" in str(col["default"]):
+            imports.add("func")
+        if col.get("foreign_key"):
+            imports.add("ForeignKey")
+    if has_relationships:
+        imports.add("relationship")
+        imports.discard("ForeignKey")
+        imports.add("ForeignKey")
+    return imports
+
+
+def _generate_table_code(
+    table_name: str,
+    columns: list[dict],
+    clickhouse_options: dict | None = None,
+    object_type: str = "table",
+) -> str:
+    class_name = "".join(part.capitalize() for part in re.split(r"[_\s]", table_name) if part)
+    if not class_name:
+        class_name = table_name.capitalize()
+
+    lines: list[str] = []
+    if object_type == "dictionary":
+        ch_opts = dict(clickhouse_options or {})
+        ch_opts["clickhouse_dictionary"] = True
+        ch_args = _format_clickhouse_args(ch_opts)
+        lines.append(f"class {class_name}(Base):")
+        lines.append(f"    __tablename__ = {table_name!r}")
+        if ch_args:
+            lines.append(f"    __table_args__ = {ch_args}")
+        for col in columns:
+            col_line = _format_column(col)
+            if col_line:
+                lines.append(f"    {col_line}")
+        return "\n".join(lines) + "\n"
+
+    if object_type == "materialized_view":
+        ch_opts = dict(clickhouse_options or {})
+        ch_opts["clickhouse_mv"] = True
+        ch_args = _format_clickhouse_args(ch_opts)
+        lines.append(f"class {class_name}(Base):")
+        lines.append(f"    __tablename__ = {table_name!r}")
+        if ch_args:
+            lines.append(f"    __table_args__ = {ch_args}")
+        for col in columns:
+            col_line = _format_column(col)
+            if col_line:
+                lines.append(f"    {col_line}")
+        return "\n".join(lines) + "\n"
+
+    lines.append(f"class {class_name}(Base):")
+    lines.append(f"    __tablename__ = {table_name!r}")
+    if clickhouse_options:
+        ch_args = _format_clickhouse_args(clickhouse_options)
+        if ch_args:
+            lines.append(f"    __table_args__ = {ch_args}")
+    for col in columns:
+        col_line = _format_column(col)
+        if col_line:
+            lines.append(f"    {col_line}")
+    return "\n".join(lines) + "\n"
+
+
+def _format_column(col: dict) -> str:
+    col_name = col["name"]
+    sa_type = _parse_type(col["type"], col.get("dialect"))
+
+    col_args = [f"Column({col_name!r}, {sa_type}"]
+    if col.get("primary_key"):
+        col_args.append("primary_key=True")
+    if not col.get("nullable", True):
+        col_args.append("nullable=False")
+    if col.get("unique"):
+        col_args.append("unique=True")
+    if col.get("foreign_key"):
+        col_args.append(f"ForeignKey('{col['foreign_key']}')")
+    default = _format_default(col.get("default"))
+    if default is not None:
+        col_args.append(f"default={default}")
+    if col.get("autoincrement") is False:
+        col_args.append("autoincrement=False")
+    col_args.append(")")
+    return ",\n        ".join(col_args)
+
+
+def _format_clickhouse_args(options: dict) -> str:
+    parts: list[str] = []
+    for key in (
+        "clickhouse_engine",
+        "clickhouse_order_by",
+        "clickhouse_primary_key",
+        "clickhouse_partition_by",
+        "clickhouse_sample_by",
+        "clickhouse_ttl",
+        "clickhouse_mv",
+        "clickhouse_mv_query",
+        "clickhouse_mv_engine",
+        "clickhouse_mv_order_by",
+        "clickhouse_mv_populate",
+        "clickhouse_projections",
+        "clickhouse_zookeeper_path",
+        "clickhouse_replica_name",
+        "clickhouse_dictionary",
+        "clickhouse_dict_layout",
+        "clickhouse_dict_source",
+        "clickhouse_dict_lifetime",
+        "clickhouse_dict_primary_key",
+    ):
+        if key in options and options[key] is not None:
+            value = options[key]
+            if isinstance(value, str):
+                parts.append(f"    {key!r}: {value!r},")
+            elif isinstance(value, bool):
+                parts.append(f"    {key!r}: {str(value)},")
+            elif isinstance(value, list):
+                items = ", ".join(repr(v) for v in value)
+                parts.append(f"    {key!r}: [{items}],")
+            elif isinstance(value, tuple):
+                items = ", ".join(repr(v) for v in value)
+                parts.append(f"    {key!r}: ({items}),")
+            elif isinstance(value, int):
+                parts.append(f"    {key!r}: {value!r},")
+            else:
+                parts.append(f"    {key!r}: {value!r},")
+    if not parts:
+        return ""
+    return "{\n" + "\n".join(parts) + "\n}"
+
+
+def _write_models(output_dir: str, tables: list[dict], single_file: bool) -> None:
+    out_path = Path(output_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    has_relationships = any(
+        col.get("foreign_key") for table in tables for col in table["columns"]
+    )
+
+    if single_file:
+        all_imports: set[str] = set()
+        all_classes: list[str] = []
+        for table in tables:
+            for col in table["columns"]:
+                col["dialect"] = table.get("dialect")
+            all_imports |= _resolve_imports(table["columns"], has_relationships)
+            all_classes.append(
+                _generate_table_code(
+                    table["name"],
+                    table["columns"],
+                    table.get("clickhouse_options"),
+                    table.get("object_type", "table"),
+                )
+            )
+
+        imports = _render_imports(all_imports)
+        content = (
+            "from sqlalchemy import " + ", ".join(sorted(imports)) + "\n"
+            if imports
+            else ""
+        )
+        if has_relationships:
+            content += "from sqlalchemy.orm import relationship\n"
+        content += (
+            "from sqlalchemy.ext.declarative import declarative_base\n\n\n"
+            "Base = declarative_base()\n\n\n"
+        )
+        content += "\n\n".join(all_classes)
+        (out_path / "models.py").write_text(content, encoding="utf-8")
+        return
+
+    seen_relations = False
+    for table in tables:
+        for col in table["columns"]:
+            col["dialect"] = table.get("dialect")
+        imports = _resolve_imports(table["columns"], has_relationships)
+        has_rel = has_relationships and any(
+            col.get("foreign_key") for col in table["columns"]
+        )
+        content_lines: list[str] = []
+        content_lines.append("from sqlalchemy import " + ", ".join(sorted(imports)) + "\n")
+        if has_rel and not seen_relations:
+            content_lines.append("from sqlalchemy.orm import relationship\n")
+            seen_relations = True
+        content_lines.append("from sqlalchemy.ext.declarative import declarative_base\n\n\n")
+        content_lines.append("Base = declarative_base()\n\n\n")
+        content_lines.append(
+            _generate_table_code(
+                table["name"],
+                table["columns"],
+                table.get("clickhouse_options"),
+                table.get("object_type", "table"),
+            )
+        )
+        safe_name = table["name"].lower().replace("-", "_")
+        (out_path / f"{safe_name}.py").write_text("".join(content_lines), encoding="utf-8")
+
+
+def _render_imports(imports: set[str]) -> set[str]:
+    result: set[str] = set()
+    for imp in sorted(imports):
+        if imp in ("Column", "ForeignKey", "func"):
+            continue
+        result.add(imp)
+    result.add("Column")
+    return result
+
+
+def generate_models_cmd(
+    output: str = "models",
+    tables: str | None = None,
+    exclude_tables: str | None = None,
+    clickhouse_engines: bool = False,
+    relationships: bool = False,
+    dialect: str | None = None,
+    single_file: bool = False,
+    database: str | None = None,
+) -> None:
+    config = get_database(database)
+    actual_dialect = dialect or config.database_type
+
+    if tables:
+        table_filter = {t.strip() for t in tables.split(",")}
+    else:
+        table_filter = None
+
+    if exclude_tables:
+        exclude_set = {t.strip() for t in exclude_tables.split(",")}
+    else:
+        exclude_set = set()
+
+    with get_db_connection(database) as connection:
+        from sqlalchemy import inspect
+
+        inspector = inspect(connection)
+        all_table_names = inspector.get_table_names()
+
+        target_tables = all_table_names
+        if table_filter:
+            target_tables = [t for t in target_tables if t in table_filter]
+        target_tables = [t for t in target_tables if t not in exclude_set]
+
+        if not target_tables:
+            console.print("No tables found matching the given criteria.", style="yellow")
+            return
+
+        tables_data: list[dict] = []
+
+        for table_name in target_tables:
+            columns_info: list[dict] = []
+
+            pk_constraint = inspector.get_pk_constraint(table_name)
+            pk_columns = set(pk_constraint.get("constrained_columns", []))
+
+            unique_constraints = inspector.get_unique_constraints(table_name)
+            unique_columns: set[str] = set()
+            for uc in unique_constraints:
+                unique_columns.update(uc.get("column_names", []))
+
+            raw_columns = inspector.get_columns(table_name)
+            foreign_keys_raw = inspector.get_foreign_keys(table_name)
+
+            fk_map: dict[str, str] = {}
+            for fk in foreign_keys_raw:
+                for constrained, referred in zip(
+                    fk.get("constrained_columns", []),
+                    fk.get("referred_columns", []) or [None] * len(fk.get("constrained_columns", [])),
+                ):
+                    if referred:
+                        fk_map[constrained] = f"{fk['referred_table']}({referred})"
+
+            for col in raw_columns:
+                col_name = col["name"]
+                col_type_str = str(col["type"])
+                col_nullable = col.get("nullable", True)
+                col_default = col.get("default")
+                col_primary = col_name in pk_columns
+                col_unique = col_name in unique_columns
+                col_fk = fk_map.get(col_name)
+
+                autoinc = getattr(col["type"], "autoincrement", None)
+                if autoinc is None:
+                    autoinc = col_primary and col_type_str.upper() in ("INTEGER", "INT", "BIGINT")
+
+                columns_info.append({
+                    "name": col_name,
+                    "type": col_type_str,
+                    "nullable": col_nullable,
+                    "default": col_default,
+                    "primary_key": col_primary,
+                    "unique": col_unique,
+                    "foreign_key": col_fk,
+                    "autoincrement": autoinc,
+                    "dialect": actual_dialect,
+                })
+
+            ch_options: dict = {}
+            if actual_dialect == "clickhouse" and clickhouse_engines:
+                ch_options = _extract_clickhouse_options(connection, table_name)
+
+            tables_data.append({
+                "name": table_name,
+                "columns": columns_info,
+                "clickhouse_options": ch_options if ch_options else None,
+                "object_type": "table",
+                "dialect": actual_dialect,
+            })
+
+    output_dir = Path(output)
+    _write_models(str(output_dir), tables_data, single_file=single_file)
+    console.print(
+        f"Generated {len(tables_data)} model(s) in '{output_dir}/'",
+        style="green",
+    )
+
+    if actual_dialect == "clickhouse":
+        for t in tables_data:
+            if t.get("clickhouse_options"):
+                for key in ("clickhouse_engine", "clickhouse_mv_query"):
+                    if key in t["clickhouse_options"]:
+                        break
+                else:
+                    console.print(
+                        f"  WARNING: ClickHouse engine metadata for '{t['name']}' may be incomplete.",
+                        style="yellow",
+                    )
+
+
+def _extract_clickhouse_options(connection, table_name: str) -> dict:
+    from sqlalchemy import text
+
+    result = connection.execute(
+        text(
+            "SELECT engine, sorting_key, primary_key, partition_key, sampling_key, create_table_query "
+            "FROM system.tables WHERE database = currentDatabase() AND name = :name"
+        ),
+        parameters={"name": table_name},
+    )
+    row = result.fetchone()
+    if not row:
+        return {}
+
+    from dbwarden.engine.safety import (
+        _parse_tuple_expression,
+        _clean_expression,
+        _parse_ttl_expressions,
+        _parse_projection_names,
+        _parse_mv_query,
+        _parse_zookeeper_path,
+        _parse_replica_name,
+    )
+
+    options: dict = {}
+    engine = getattr(row, "engine", "") or ""
+    if engine:
+        options["clickhouse_engine"] = engine
+    sorting_key = _parse_tuple_expression(getattr(row, "sorting_key", None))
+    if sorting_key:
+        options["clickhouse_order_by"] = sorting_key
+    primary_key = _parse_tuple_expression(getattr(row, "primary_key", None))
+    if primary_key:
+        options["clickhouse_primary_key"] = primary_key
+    partition_key = _clean_expression(getattr(row, "partition_key", None))
+    if partition_key:
+        options["clickhouse_partition_by"] = partition_key
+    sampling_key = _clean_expression(getattr(row, "sampling_key", None))
+    if sampling_key:
+        options["clickhouse_sample_by"] = sampling_key
+
+    create_query = getattr(row, "create_table_query", "") or ""
+    ttl = _parse_ttl_expressions(create_query)
+    if ttl:
+        options["clickhouse_ttl"] = ttl
+    projections = _parse_projection_names(create_query)
+    if projections:
+        options["clickhouse_projections"] = [{"name": p, "query": ""} for p in projections]
+    mv_query = _parse_mv_query(create_query)
+    if mv_query:
+        options["clickhouse_mv_query"] = mv_query
+    zk_path = _parse_zookeeper_path(create_query, engine)
+    if zk_path:
+        options["clickhouse_zookeeper_path"] = zk_path
+    replica = _parse_replica_name(create_query, engine)
+    if replica:
+        options["clickhouse_replica_name"] = replica
+
+    if engine.upper() == "DICTIONARY":
+        options["clickhouse_dictionary"] = True
+
+    if create_query.strip().upper().startswith("CREATE MATERIALIZED VIEW"):
+        options["clickhouse_mv"] = True
+
+    return options

--- a/dbwarden/commands/make_migrations.py
+++ b/dbwarden/commands/make_migrations.py
@@ -190,13 +190,16 @@ def build_migration_plan(
 
 
 def _build_plan_operation(change: Change) -> dict[str, str]:
-    operation = {
+    operation: dict[str, str] = {
         "type": change.operation,
         "table": change.table,
         "severity": "INFO",
     }
     if change.target:
-        operation["column"] = change.target
+        if change.operation == "rename_column":
+            operation["new_name"] = change.target
+        else:
+            operation["column"] = change.target
     return operation
 
 
@@ -213,6 +216,9 @@ def generate_migration_sql(
     - CREATE TABLE for new tables
     - ALTER TABLE ADD COLUMN for new columns in existing tables
 
+    When a schema snapshot exists, it uses the snapshot for rename detection.
+    Otherwise falls back to diffing against the live database.
+
     Args:
         tables: List of ModelTable objects.
         migrations_dir: Path to migrations directory.
@@ -222,74 +228,112 @@ def generate_migration_sql(
     Returns:
         Tuple of (upgrade_sql, rollback_sql, changes).
     """
-    try:
-        config = get_database(database)
-        existing_tables = extract_tables_from_database(config.sqlalchemy_url)
-    except Exception:
-        existing_tables = {}
-
-    migration_tables = {}
-    if migrations_dir:
-        migration_tables = extract_tables_from_migrations(migrations_dir)
-
-    known_tables: dict[str, set[str]] = {
-        table_name: {col.lower() for col in columns}
-        for table_name, columns in existing_tables.items()
-    }
-    for table_name, columns in migration_tables.items():
-        if table_name in known_tables:
-            known_tables[table_name].update({col.lower() for col in columns})
-        else:
-            known_tables[table_name] = {col.lower() for col in columns}
-
-    upgrade_parts = []
-    rollback_parts = []
+    upgrade_sql: str = ""
+    rollback_sql: str = ""
     changes: list[Change] = []
+    snapshot: Any = None
 
-    for table in tables:
-        existing_columns = known_tables.get(table.name, set())
+    try:
+        from dbwarden.engine.snapshot import (
+            find_latest_snapshot,
+            diff_models_against_snapshot,
+            snapshot_diff_to_sql,
+        )
 
-        if not existing_columns:
-            create_sql = generate_create_table_sql(table, db_name)
-            upgrade_parts.append(create_sql)
-            rollback_parts.append(generate_drop_object_sql(table))
-            changes.append(Change(operation="create_table", table=table.name))
-        else:
-            for column in table.columns:
-                if column.name.lower() not in existing_columns:
-                    alter_sql = generate_add_column_sql(table.name, column, db_name)
-                    upgrade_parts.append(alter_sql)
-                    rollback_parts.append(
-                        f"ALTER TABLE {table.name} DROP COLUMN {column.name}"
-                    )
-                    changes.append(Change(operation="add_column", table=table.name, target=column.name))
+        snapshot = find_latest_snapshot(database)
+    except Exception:
+        snapshot = None
 
-                    known_tables.setdefault(table.name, set()).add(column.name.lower())
+    if snapshot is not None:
+        try:
+            upgrade_ops, rollback_ops = diff_models_against_snapshot(
+                tables, snapshot, database=database, db_name=db_name
+            )
+            upgrade_sql, rollback_sql, changes = snapshot_diff_to_sql(
+                upgrade_ops, rollback_ops, database=database, db_name=db_name
+            )
+        except Exception:
+            snapshot = None
 
-    rollback_parts.reverse()
+    if snapshot is None:
+        try:
+            config = get_database(database)
+            existing_tables = extract_tables_from_database(config.sqlalchemy_url)
+        except Exception:
+            existing_tables = {}
+
+        migration_tables = {}
+        if migrations_dir:
+            migration_tables = extract_tables_from_migrations(migrations_dir)
+
+        known_tables: dict[str, set[str]] = {
+            table_name: {col.lower() for col in columns}
+            for table_name, columns in existing_tables.items()
+        }
+        for table_name, columns in migration_tables.items():
+            if table_name in known_tables:
+                known_tables[table_name].update({col.lower() for col in columns})
+            else:
+                known_tables[table_name] = {col.lower() for col in columns}
+
+        upgrade_parts: list[str] = []
+        rollback_parts: list[str] = []
+        changes: list[Change] = []
+
+        for table in tables:
+            existing_columns = known_tables.get(table.name, set())
+
+            if not existing_columns:
+                create_sql = generate_create_table_sql(table, db_name)
+                upgrade_parts.append(create_sql)
+                rollback_parts.append(generate_drop_object_sql(table))
+                changes.append(Change(operation="create_table", table=table.name))
+            else:
+                for column in table.columns:
+                    if column.name.lower() not in existing_columns:
+                        alter_sql = generate_add_column_sql(table.name, column, db_name)
+                        upgrade_parts.append(alter_sql)
+                        rollback_parts.append(
+                            f"ALTER TABLE {table.name} DROP COLUMN {column.name}"
+                        )
+                        changes.append(Change(operation="add_column", table=table.name, target=column.name))
+                        known_tables.setdefault(table.name, set()).add(column.name.lower())
+
+        rollback_parts.reverse()
+
+        if migrations_dir:
+            existing_statements = get_pending_migration_statements(migrations_dir)
+            filtered_upgrade_parts = []
+            filtered_rollback_parts = []
+            filtered_changes = []
+
+            for upgrade_sql, rollback_sql in zip(upgrade_parts, rollback_parts):
+                if upgrade_sql.strip() in existing_statements:
+                    continue
+                filtered_upgrade_parts.append(upgrade_sql)
+                filtered_rollback_parts.append(rollback_sql)
+
+            for change, upgrade_sql in zip(changes, upgrade_parts):
+                if upgrade_sql.strip() in existing_statements:
+                    continue
+                filtered_changes.append(change)
+
+            upgrade_parts = filtered_upgrade_parts
+            rollback_parts = filtered_rollback_parts
+            changes = filtered_changes
+
+        upgrade_sql = "\n\n".join(upgrade_parts)
+        rollback_sql = "\n\n".join(rollback_parts)
 
     if migrations_dir:
         existing_statements = get_pending_migration_statements(migrations_dir)
-        filtered_upgrade_parts = []
-        filtered_rollback_parts = []
-        filtered_changes = []
+        if upgrade_sql.strip():
+            from dbwarden.engine.snapshot import _filter_duplicates_from_snapshot_diff
+            upgrade_sql, rollback_sql, changes = _filter_duplicates_from_snapshot_diff(
+                upgrade_sql, rollback_sql, changes, existing_statements
+            )
 
-        for upgrade_sql, rollback_sql in zip(upgrade_parts, rollback_parts):
-            if upgrade_sql.strip() in existing_statements:
-                continue
-            filtered_upgrade_parts.append(upgrade_sql)
-            filtered_rollback_parts.append(rollback_sql)
-
-        for change, upgrade_sql in zip(changes, upgrade_parts):
-            if upgrade_sql.strip() in existing_statements:
-                continue
-            filtered_changes.append(change)
-
-        upgrade_parts = filtered_upgrade_parts
-        rollback_parts = filtered_rollback_parts
-        changes = filtered_changes
-
-    return "\n\n".join(upgrade_parts), "\n\n".join(rollback_parts), changes
+    return upgrade_sql, rollback_sql, changes
 
 
 def new_migration_cmd(

--- a/dbwarden/commands/make_rollback.py
+++ b/dbwarden/commands/make_rollback.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from dbwarden.output import console
+
+
+def _reverse_sql(sql: str) -> str:
+    stripped = sql.strip()
+    upper = stripped.upper()
+    if upper.startswith("CREATE TABLE"):
+        match = re.search(r"CREATE TABLE\s+(?:IF NOT EXISTS\s+)?(\S+)", stripped, re.IGNORECASE)
+        if match:
+            table_name = match.group(1).rstrip("(").strip()
+            return f"DROP TABLE IF EXISTS {table_name};"
+    elif upper.startswith("CREATE MATERIALIZED VIEW"):
+        match = re.search(r"CREATE MATERIALIZED VIEW\s+(?:IF NOT EXISTS\s+)?(\S+)", stripped, re.IGNORECASE)
+        if match:
+            view_name = match.group(1).rstrip("(").strip()
+            return f"DROP VIEW IF EXISTS {view_name};"
+    elif upper.startswith("CREATE DICTIONARY"):
+        match = re.search(r"CREATE DICTIONARY\s+(?:IF NOT EXISTS\s+)?(\S+)", stripped, re.IGNORECASE)
+        if match:
+            dict_name = match.group(1).rstrip("(").strip()
+            return f"DROP DICTIONARY IF EXISTS {dict_name};"
+    elif upper.startswith("ALTER TABLE"):
+        alter_match = re.search(
+            r"ALTER TABLE\s+(\S+)\s+ADD\s+COLUMN(?:\s+IF NOT EXISTS)?\s+(\S+)",
+            stripped,
+            re.IGNORECASE,
+        )
+        if alter_match:
+            table_name = alter_match.group(1)
+            column_name = alter_match.group(2)
+            return f"ALTER TABLE {table_name} DROP COLUMN {column_name};"
+    elif upper.startswith("CREATE INDEX"):
+        match = re.search(r"CREATE INDEX\s+(?:IF NOT EXISTS\s+)?(\S+)", stripped, re.IGNORECASE)
+        if match:
+            index_name = match.group(1)
+            return f"DROP INDEX IF EXISTS {index_name};"
+    elif upper.startswith("CREATE UNIQUE INDEX"):
+        match = re.search(r"CREATE UNIQUE INDEX\s+(?:IF NOT EXISTS\s+)?(\S+)", stripped, re.IGNORECASE)
+        if match:
+            index_name = match.group(1)
+            return f"DROP INDEX IF EXISTS {index_name};"
+
+    return f"-- No automatic rollback generated for:\n-- {sql}"
+
+
+def make_rollback_cmd(migration_file: str) -> None:
+    path = Path(migration_file)
+    if not path.exists():
+        console.print(f"Migration file not found: {migration_file}", style="red")
+        return
+
+    content = path.read_text(encoding="utf-8")
+
+    upgrade_section = ""
+    in_upgrade = False
+    for line in content.splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped == "-- upgrade":
+            in_upgrade = True
+            continue
+        if stripped == "-- rollback":
+            break
+        if in_upgrade:
+            upgrade_section += line
+
+    if not upgrade_section.strip():
+        console.print("No upgrade SQL found in migration file.", style="yellow")
+        return
+
+    statements = [
+        s.strip() for s in upgrade_section.split(";") if s.strip() and not s.strip().startswith("--")
+    ]
+    rollback_statements = [_reverse_sql(s) for s in statements]
+
+    out_path = path.with_suffix(".rollback.sql")
+    out_path.write_text(
+        "-- rollback\n\n" + "\n\n".join(rollback_statements) + "\n",
+        encoding="utf-8",
+    )
+
+    console.print(f"Created rollback file: {out_path}", style="green")

--- a/dbwarden/commands/migrate.py
+++ b/dbwarden/commands/migrate.py
@@ -288,6 +288,11 @@ def migrate_single(
                 db_name=db_name,
             )
 
+            _write_migration_snapshot(
+                db_name=db_name,
+                migration_id=Path(filename).stem,
+            )
+
             duration = time.time() - start_time
             logger.log_migration_end(version, filename, duration)
             versioned_count += 1
@@ -443,6 +448,26 @@ def migrate_cmd(
             dry_run=dry_run,
             sandbox=sandbox,
         )
+
+
+def _write_migration_snapshot(
+    db_name: str | None = None,
+    migration_id: str = "",
+) -> None:
+    from dbwarden.engine.snapshot import extract_full_schema_snapshot, write_snapshot
+
+    try:
+        snapshot = extract_full_schema_snapshot(database=db_name)
+        filepath = write_snapshot(
+            snapshot,
+            database=db_name,
+            migration_id=migration_id,
+        )
+        logger = get_logger(db_name=db_name)
+        logger.info(f"Schema snapshot written: {filepath}")
+    except Exception as exc:
+        logger = get_logger(db_name=db_name)
+        logger.warning(f"Failed to write schema snapshot: {exc}")
 
 
 def _get_filepaths_by_version(

--- a/dbwarden/commands/snapshot.py
+++ b/dbwarden/commands/snapshot.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from dbwarden.config import get_database
+from dbwarden.database.connection import get_db_connection
+from dbwarden.output import console
+
+
+def snapshot_cmd(
+    table_name: str,
+    database: str | None = None,
+) -> None:
+    config = get_database(database)
+    db_type = config.database_type
+
+    with get_db_connection(database) as connection:
+        if db_type == "clickhouse":
+            _snapshot_clickhouse(connection, table_name)
+        else:
+            _snapshot_generic(connection, table_name)
+
+
+def _snapshot_generic(connection, table_name: str) -> None:
+    from sqlalchemy import inspect
+
+    inspector = inspect(connection)
+    all_tables = inspector.get_table_names()
+    if table_name not in all_tables:
+        console.print(f"Table '{table_name}' not found in database.", style="red")
+        return
+
+    columns = inspector.get_columns(table_name)
+    indexes = inspector.get_indexes(table_name)
+    foreign_keys = inspector.get_foreign_keys(table_name)
+
+    lines = [f"CREATE TABLE {table_name} ("]
+    col_defs = []
+    for col in columns:
+        col_type = str(col["type"])
+        nullable = "" if col.get("nullable", True) else " NOT NULL"
+        default = ""
+        if col.get("default") is not None and str(col["default"]) != "None":
+            default = f" DEFAULT {col['default']}"
+        col_defs.append(f"    {col['name']} {col_type}{nullable}{default}")
+    lines.append(",\n".join(col_defs))
+    lines.append(");")
+
+    console.print("\n".join(lines), style="white", markup=False)
+
+    if indexes:
+        console.print("\n-- Indexes:", style="dim")
+        for idx in indexes:
+            cols = ", ".join(idx["column_names"])
+            unique = "UNIQUE " if idx.get("unique") else ""
+            console.print(
+                f"CREATE {unique}INDEX {idx['name']} ON {table_name} ({cols});",
+                style="white",
+                markup=False,
+            )
+
+    if foreign_keys:
+        console.print("\n-- Foreign Keys:", style="dim")
+        for fk in foreign_keys:
+            cols = ", ".join(fk["constrained_columns"])
+            ref_cols = ", ".join(fk["referred_columns"])
+            console.print(
+                f"ALTER TABLE {table_name} ADD CONSTRAINT {fk['name']} "
+                f"FOREIGN KEY ({cols}) REFERENCES {fk['referred_table']} ({ref_cols});",
+                style="white",
+                markup=False,
+            )
+
+
+def _snapshot_clickhouse(connection, table_name: str) -> None:
+    from sqlalchemy import text
+
+    result = connection.execute(
+        text(
+            "SELECT create_table_query FROM system.tables "
+            "WHERE database = currentDatabase() AND name = :name"
+        ),
+        parameters={"name": table_name},
+    )
+    row = result.fetchone()
+    if not row:
+        console.print(f"Table '{table_name}' not found in database.", style="red")
+        return
+
+    console.print(row.create_table_query, style="white", markup=False)

--- a/dbwarden/engine/migration_name.py
+++ b/dbwarden/engine/migration_name.py
@@ -121,6 +121,7 @@ def _pluralize(operation: str) -> str:
     singular_to_plural = {
         "add_column": "add_columns",
         "drop_column": "drop_columns",
+        "rename_column": "rename_columns",
         "create_table": "create_tables",
         "drop_table": "drop_tables",
         "add_index": "add_indexes",
@@ -138,8 +139,8 @@ def _truncate(name: str) -> str:
         return name
 
     parts = name.split("_")
-    op_words = {"add", "drop", "alter", "create", "adds", "drops", "alters", "creates", 
-               "add_columns", "drop_columns", "create_tables", "drop_tables",
+    op_words = {"add", "drop", "alter", "create", "rename", "adds", "drops", "alters", "creates", "renames",
+               "add_columns", "drop_columns", "rename_columns", "create_tables", "drop_tables",
                "add_indexes", "drop_indexes", "add_foreign_keys", "drop_foreign_keys",
                "add_constraints", "drop_constraints"}
     

--- a/dbwarden/engine/snapshot.py
+++ b/dbwarden/engine/snapshot.py
@@ -1,0 +1,643 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+from datetime import datetime, timezone
+from typing import Any
+
+from dbwarden.engine.model_discovery import ModelColumn, ModelTable
+
+
+TYPE_NORMALIZATION_MAP: dict[str, str | None] = {
+    "int": "integer",
+    "integer": "integer",
+    "int4": "integer",
+    "tinyint": "integer",
+    "smallint": "integer",
+    "int2": "integer",
+    "bigint": "biginteger",
+    "int8": "biginteger",
+    "varchar": "varchar",
+    "character varying": "varchar",
+    "text": "text",
+    "longtext": "text",
+    "clob": "text",
+    "mediumtext": "text",
+    "boolean": "boolean",
+    "bool": "boolean",
+    "timestamp": "timestamp",
+    "datetime": "timestamp",
+    "date": "date",
+    "float": "float",
+    "real": "float",
+    "double precision": "float",
+    "double": "float",
+    "numeric": "numeric",
+    "decimal": "numeric",
+    "json": "json",
+    "jsonb": "json",
+    "uuid": "uuid",
+    "bytea": "bytes",
+    "blob": "bytes",
+    "binary": "bytes",
+    "varbinary": "bytes",
+    "enum": "enum",
+}
+
+_RAW_TYPE_PATTERN = re.compile(r"^([a-zA-Z][a-zA-Z0-9_]*)(?:\((\d+)(?:\s*,\s*(\d+))?\))?\s*$")
+
+
+def normalize_type(raw_type: str) -> dict[str, Any]:
+    raw_clean = raw_type.strip().lower()
+    raw_no_parens = re.sub(r"\(.*?\)", "", raw_clean).strip()
+    raw_no_parens_clean = re.sub(r"\s+", " ", raw_no_parens).strip()
+    normalized = TYPE_NORMALIZATION_MAP.get(raw_no_parens_clean)
+    if normalized is None:
+        base = re.sub(r"[^a-z0-9]", "", raw_no_parens_clean) if raw_no_parens_clean else ""
+        normalized = TYPE_NORMALIZATION_MAP.get(base)
+    if normalized is None:
+        base = re.sub(r"[^a-z]", "", raw_no_parens_clean) if raw_no_parens_clean else ""
+        normalized = TYPE_NORMALIZATION_MAP.get(base)
+    if normalized is not None:
+        result: dict[str, Any] = {"type": normalized}
+        full_lower = raw_type.strip().lower()
+        length_match = re.search(r"\((\d+)\)", full_lower)
+        if length_match and normalized in ("varchar",):
+            result["length"] = int(length_match.group(1))
+        precision_scale = re.search(r"\((\d+),\s*(\d+)\)", full_lower)
+        if precision_scale and normalized in ("numeric",):
+            result["precision"] = int(precision_scale.group(1))
+            result["scale"] = int(precision_scale.group(2))
+        return result
+    fallback_match = _RAW_TYPE_PATTERN.match(raw_type.strip())
+    if fallback_match:
+        return {"type": raw_type.strip(), "raw": True}
+    return {"type": raw_type.strip(), "raw": True}
+
+
+def _is_autoincrement(column: dict[str, Any]) -> bool:
+    type_str = str(column.get("type", "")).lower()
+    if any(kw in type_str for kw in ("serial", "bigserial", "smallserial")):
+        return True
+    if column.get("autoincrement"):
+        return True
+    if column.get("primary_key") and type_str in ("integer", "bigint", "int", "smallint"):
+        return True
+    return False
+
+
+def _get_generic_type_name(col_type: Any) -> str:
+    type_str = str(col_type)
+    if hasattr(col_type, "display_args") and hasattr(col_type, "as_generic"):
+        try:
+            generic = col_type.as_generic()
+            if generic is not None:
+                return str(generic)
+        except Exception:
+            pass
+    return type_str
+
+
+def extract_full_schema_snapshot(
+    database: str | None = None,
+    sqlalchemy_url: str | None = None,
+    database_type: str | None = None,
+) -> dict[str, Any]:
+    from sqlalchemy import inspect, text
+
+    db_name = database or "default"
+
+    if sqlalchemy_url is not None and database_type is not None:
+        from sqlalchemy import create_engine
+        engine = create_engine(sqlalchemy_url)
+        inspector = inspect(engine)
+        own_engine = True
+    else:
+        from dbwarden.database.connection import get_db_connection
+        conn_context = get_db_connection(database)
+        connection = conn_context.__enter__()
+        try:
+            inspector = inspect(connection)
+        except Exception:
+            conn_context.__exit__(None, None, None)
+            raise
+        engine = None
+        own_engine = False
+        from dbwarden.config import get_database
+        database_type = get_database(database).database_type
+
+    tables: dict[str, Any] = {}
+    enums: dict[str, Any] = {}
+    indexes: dict[str, Any] = {}
+    constraints: dict[str, Any] = {}
+
+    for table_name in inspector.get_table_names():
+        columns_info = inspector.get_columns(table_name)
+        pk_info = inspector.get_pk_constraint(table_name)
+
+        pk_columns = set(pk_info.get("constrained_columns", []) or [])
+
+        columns_dict: dict[str, Any] = {}
+        for col in columns_info:
+            col_name = col["name"]
+            col_type = col.get("type", "")
+            raw_type_str = str(col_type)
+            normalized = normalize_type(raw_type_str)
+            col_type_name = normalized["type"]
+            is_pk = col_name in pk_columns
+            col_entry: dict[str, Any] = {
+                "type": col_type_name,
+                "nullable": bool(col.get("nullable", True)),
+                "primary_key": is_pk,
+                "default": col.get("default"),
+                "autoincrement": _is_autoincrement(col),
+            }
+            if normalized.get("raw"):
+                col_entry["raw"] = True
+            if "length" in normalized:
+                col_entry["length"] = normalized["length"]
+            if "precision" in normalized:
+                col_entry["precision"] = normalized["precision"]
+            if "scale" in normalized:
+                col_entry["scale"] = normalized["scale"]
+
+            enum_match = re.match(r"^([a-zA-Z_][a-zA-Z0-9_]*)$", raw_type_str)
+            if database_type == "postgresql" and enum_match:
+                with engine.connect() as conn:
+                    result = conn.execute(
+                        text(
+                            "SELECT t.typname FROM pg_type t "
+                            "JOIN pg_enum e ON t.oid = e.enumtypid "
+                            "WHERE t.typname = :tname LIMIT 1"
+                        ),
+                        {"tname": raw_type_str},
+                    )
+                    if result.fetchone():
+                        col_entry["enum_name"] = raw_type_str
+
+            comment = col.get("comment")
+            if comment is not None:
+                col_entry["comment"] = comment
+
+            columns_dict[col_name] = col_entry
+
+        table_entry: dict[str, Any] = {
+            "columns": columns_dict,
+            "primary_key": list(pk_columns) if pk_columns else [],
+            "comment": None,
+        }
+
+        if database_type == "postgresql":
+            try:
+                table_comment = inspector.get_table_comment(table_name)
+                if table_comment and table_comment.get("text"):
+                    table_entry["comment"] = table_comment["text"]
+            except Exception:
+                pass
+
+        tables[table_name] = table_entry
+
+        for idx in inspector.get_indexes(table_name):
+            idx_name = idx.get("name", "")
+            if not idx_name:
+                continue
+            if idx.get("unique") and set(idx.get("column_names", [])) == pk_columns:
+                continue
+            indexes[idx_name] = {
+                "table": table_name,
+                "columns": list(idx.get("column_names", [])),
+                "unique": bool(idx.get("unique", False)),
+                "type": idx.get("dialect_options", {}).get("sqlite_using", "btree"),
+            }
+
+        for fk in inspector.get_foreign_keys(table_name):
+            fk_name = fk.get("name", "")
+            if not fk_name:
+                fk_name = f"fk_{table_name}_{'_'.join(fk.get('constrained_columns', []))}"
+            constraints[fk_name] = {
+                "type": "foreign_key",
+                "table": table_name,
+                "columns": list(fk.get("constrained_columns", [])),
+                "referenced_table": fk.get("referred_table", ""),
+                "referenced_columns": list(fk.get("referred_columns", [])),
+                "on_delete": fk.get("options", {}).get("ondelete", "NO ACTION"),
+                "on_update": fk.get("options", {}).get("onupdate", "NO ACTION"),
+            }
+
+        for uq in inspector.get_unique_constraints(table_name):
+            uq_name = uq.get("name", "")
+            if not uq_name:
+                continue
+            constraints[uq_name] = {
+                "type": "unique",
+                "table": table_name,
+                "columns": list(uq.get("column_names", [])),
+            }
+
+        for ck in inspector.get_check_constraints(table_name):
+            ck_name = ck.get("name", "")
+            if not ck_name:
+                ck_name = f"ck_{table_name}_{hash(ck.get('sqltext', ''))}"
+            constraints[ck_name] = {
+                "type": "check",
+                "table": table_name,
+                "columns": [],
+                "expression": ck.get("sqltext", ""),
+            }
+
+    if database_type == "postgresql":
+        try:
+            for enum_info in inspector.get_enums():
+                enums[enum_info["name"]] = list(enum_info.get("labels", []))
+        except Exception:
+            pass
+
+    if own_engine and engine is not None:
+        engine.dispose()
+    else:
+        try:
+            conn_context.__exit__(None, None, None)
+        except Exception:
+            pass
+
+    return {
+        "format_version": 1,
+        "migration_id": "",
+        "database_name": db_name,
+        "database_type": database_type or "",
+        "applied_at": "",
+        "tables": tables,
+        "enums": enums,
+        "indexes": indexes,
+        "constraints": constraints,
+    }
+
+
+def compute_checksum(snapshot: dict[str, Any]) -> str:
+    snapshot_copy = {k: v for k, v in snapshot.items() if k != "checksum"}
+    raw = json.dumps(snapshot_copy, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def get_schemas_directory(database: str | None = None) -> str:
+    base_dir = os.path.join(os.getcwd(), "dbwarden", "schemas")
+    os.makedirs(base_dir, exist_ok=True)
+    return base_dir
+
+
+def write_snapshot(
+    snapshot: dict[str, Any],
+    database: str | None = None,
+    migration_id: str = "",
+) -> str:
+    from dbwarden.config import get_database
+
+    config = get_database(database)
+    db_name = database or config.sqlalchemy_url.split("/")[-1].split("?")[0]
+
+    snapshot["migration_id"] = migration_id
+    snapshot["database_name"] = db_name
+    snapshot["database_type"] = config.database_type
+    snapshot["applied_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    checksum = compute_checksum(snapshot)
+    snapshot["checksum"] = checksum
+
+    schemas_dir = get_schemas_directory(database)
+    filename = f"{migration_id}.schema.json"
+    filepath = os.path.join(schemas_dir, filename)
+
+    fd, tmp_path = tempfile.mkstemp(dir=schemas_dir, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(snapshot, f, indent=2, ensure_ascii=False, default=str)
+            f.write("\n")
+        os.replace(tmp_path, filepath)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except Exception:
+            pass
+        raise
+
+    return filepath
+
+
+def read_snapshot(filepath: str) -> dict[str, Any] | None:
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            snapshot = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
+
+    stored_checksum = snapshot.pop("checksum", None)
+    if stored_checksum is not None:
+        actual = compute_checksum(snapshot)
+        snapshot["checksum"] = stored_checksum
+        if actual != stored_checksum:
+            return None
+    else:
+        snapshot["checksum"] = ""
+
+    return snapshot
+
+
+def find_latest_snapshot(database: str | None = None) -> dict[str, Any] | None:
+    schemas_dir = get_schemas_directory(database)
+
+    if not os.path.isdir(schemas_dir):
+        return None
+
+    db_name = database or "default"
+
+    prefix = f"{db_name}__"
+    candidates: list[tuple[str, str]] = []
+
+    for fname in os.listdir(schemas_dir):
+        if not fname.endswith(".schema.json"):
+            continue
+        if not fname.startswith(prefix):
+            continue
+        stem = fname[: -len(".schema.json")]
+        migration_id = stem
+        version_match = re.search(r"__(\d{4})_", migration_id)
+        if version_match:
+            version = version_match.group(1)
+            candidates.append((version, os.path.join(schemas_dir, fname)))
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda x: x[0])
+    latest_path = candidates[-1][1]
+    return read_snapshot(latest_path)
+
+
+def extract_snapshot_tables(snapshot: dict[str, Any]) -> dict[str, set[str]]:
+    tables: dict[str, set[str]] = {}
+    for table_name, table_def in snapshot.get("tables", {}).items():
+        tables[table_name] = set(table_def.get("columns", {}).keys())
+    return tables
+
+
+def detect_renames(
+    table_name: str,
+    dropped_columns: list[tuple[str, dict[str, Any]]],
+    added_columns: list[tuple[str, ModelColumn]],
+) -> list[tuple[str, str]]:
+    renames: list[tuple[str, str]] = []
+
+    if not dropped_columns or not added_columns:
+        return renames
+
+    dropped_by_type: dict[str, list[tuple[str, dict[str, Any]]]] = {}
+    for col_name, col_def in dropped_columns:
+        col_type = col_def.get("type", "")
+        dropped_by_type.setdefault(col_type, []).append((col_name, col_def))
+
+    added_by_type: dict[str, list[tuple[str, ModelColumn]]] = {}
+    for col_name, model_col in added_columns:
+        col_type = normalize_type(model_col.type)["type"]
+        added_by_type.setdefault(col_type, []).append((col_name, model_col))
+
+    used_dropped: set[str] = set()
+    used_added: set[str] = set()
+
+    for col_type in list(dropped_by_type.keys()):
+        if col_type not in added_by_type:
+            continue
+
+        drops = dropped_by_type[col_type]
+        adds = added_by_type[col_type]
+
+        available_drops = [(n, d) for n, d in drops if n not in used_dropped]
+        available_adds = [(n, m) for n, m in adds if n not in used_added]
+
+        if not available_drops or not available_adds:
+            continue
+
+        if len(available_drops) == 1 and len(available_adds) == 1:
+            drop_name = available_drops[0][0]
+            add_name = available_adds[0][0]
+            if drop_name != add_name:
+                renames.append((drop_name, add_name))
+                used_dropped.add(drop_name)
+                used_added.add(add_name)
+        elif len(available_drops) == len(available_adds):
+            for drop_name, _ in available_drops:
+                if drop_name not in used_dropped:
+                    for add_name, _ in available_adds:
+                        if add_name not in used_added:
+                            renames.append((drop_name, add_name))
+                            used_dropped.add(drop_name)
+                            used_added.add(add_name)
+                            break
+
+    return renames
+
+
+def diff_models_against_snapshot(
+    model_tables: list[ModelTable],
+    snapshot: dict[str, Any],
+    database: str | None = None,
+    db_name: str | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    upgrade_ops: list[dict[str, Any]] = []
+    rollback_ops: list[dict[str, Any]] = []
+
+    snapshot_tables = snapshot.get("tables", {})
+    model_by_name = {t.name: t for t in model_tables}
+
+    for table in model_tables:
+        if table.name not in snapshot_tables:
+            upgrade_ops.append({
+                "type": "create_table",
+                "table": table.name,
+                "sql": None,
+            })
+            rollback_ops.append({
+                "type": "drop_table",
+                "table": table.name,
+            })
+
+    for snap_table_name in snapshot_tables:
+        if snap_table_name not in model_by_name:
+            upgrade_ops.append({
+                "type": "drop_table",
+                "table": snap_table_name,
+            })
+            rollback_ops.append({
+                "type": "create_table",
+                "table": snap_table_name,
+                "sql": None,
+            })
+
+    for table in model_tables:
+        if table.name not in snapshot_tables:
+            continue
+
+        snap_columns = snapshot_tables[table.name].get("columns", {})
+        model_columns = {c.name: c for c in table.columns}
+
+        dropped_cols = []
+        for col_name in snap_columns:
+            if col_name not in model_columns:
+                dropped_cols.append((col_name, snap_columns[col_name]))
+
+        added_cols = []
+        for col_name, model_col in model_columns.items():
+            if col_name not in snap_columns:
+                added_cols.append((col_name, model_col))
+
+        renames = detect_renames(table.name, dropped_cols, added_cols)
+
+        renamed_old = {old for old, _ in renames}
+        renamed_new = {new for _, new in renames}
+
+        for old_name, new_name in renames:
+            upgrade_ops.append({
+                "type": "rename_column",
+                "table": table.name,
+                "old_name": old_name,
+                "new_name": new_name,
+            })
+            rollback_ops.append({
+                "type": "rename_column",
+                "table": table.name,
+                "old_name": new_name,
+                "new_name": old_name,
+            })
+
+        for col_name, col_def in dropped_cols:
+            if col_name in renamed_old:
+                continue
+            upgrade_ops.append({
+                "type": "drop_column",
+                "table": table.name,
+                "column": col_name,
+            })
+            rollback_ops.append({
+                "type": "add_column",
+                "table": table.name,
+                "column": col_name,
+                "definition": col_def,
+            })
+
+        for col_name, model_col in added_cols:
+            if col_name in renamed_new:
+                continue
+            upgrade_ops.append({
+                "type": "add_column",
+                "table": table.name,
+                "column": col_name,
+                "model_column": model_col,
+            })
+            rollback_ops.append({
+                "type": "drop_column",
+                "table": table.name,
+                "column": col_name,
+            })
+
+    return upgrade_ops, rollback_ops
+
+
+def snapshot_diff_to_sql(
+    upgrade_ops: list[dict[str, Any]],
+    rollback_ops: list[dict[str, Any]],
+    database: str | None = None,
+    db_name: str | None = None,
+) -> tuple[str, str, list[Any]]:
+    from dbwarden.engine.model_discovery import (
+        generate_add_column_sql,
+        generate_create_table_sql,
+        generate_drop_object_sql,
+    )
+    from dbwarden.engine.migration_name import Change
+
+    upgrade_parts: list[str] = []
+    rollback_parts: list[str] = []
+    changes: list[Change] = []
+
+    for op in upgrade_ops:
+        if op["type"] == "create_table":
+            table = _find_model_table(op["table"], db_name=db_name)
+            if table:
+                sql = generate_create_table_sql(table, db_name)
+                upgrade_parts.append(sql)
+                changes.append(Change(operation="create_table", table=op["table"]))
+            rollback_parts.append(generate_drop_object_sql(
+                _find_model_table(op["table"], db_name=db_name) or ModelTable(name=op["table"], columns=[])
+            ))
+        elif op["type"] == "drop_table":
+            upgrade_parts.append(f"DROP TABLE {op['table']}")
+            rollback_parts.append(f"CREATE TABLE {op['table']} (/* restore from snapshot */)")
+            changes.append(Change(operation="drop_table", table=op["table"]))
+        elif op["type"] == "rename_column":
+            upgrade_parts.append(f"ALTER TABLE {op['table']} RENAME COLUMN {op['old_name']} TO {op['new_name']}")
+            rollback_parts.append(f"ALTER TABLE {op['table']} RENAME COLUMN {op['new_name']} TO {op['old_name']}")
+            changes.append(Change(operation="rename_column", table=op["table"], target=op["new_name"]))
+        elif op["type"] == "add_column":
+            model_col = op.get("model_column")
+            if model_col:
+                sql = generate_add_column_sql(op["table"], model_col, db_name)
+                upgrade_parts.append(sql)
+            else:
+                col_def = op.get("definition", {})
+                upgrade_parts.append(
+                    f"ALTER TABLE {op['table']} ADD COLUMN {op['column']} {col_def.get('type', '???')}"
+                )
+            rollback_parts.append(f"ALTER TABLE {op['table']} DROP COLUMN {op['column']}")
+            changes.append(Change(operation="add_column", table=op["table"], target=op["column"]))
+        elif op["type"] == "drop_column":
+            upgrade_parts.append(f"ALTER TABLE {op['table']} DROP COLUMN {op['column']}")
+            rollback_parts.append(f"ALTER TABLE {op['table']} ADD COLUMN {op['column']} {op.get('definition', {}).get('type', '???')}")
+            changes.append(Change(operation="drop_column", table=op["table"], target=op["column"]))
+
+    rollback_parts.reverse()
+    return "\n\n".join(upgrade_parts), "\n\n".join(rollback_parts), changes
+
+
+def _filter_duplicates_from_snapshot_diff(
+    upgrade_sql: str,
+    rollback_sql: str,
+    changes: list[Any],
+    existing_statements: set[str],
+) -> tuple[str, str, list[Any]]:
+    upgrade_parts = [s.strip() for s in upgrade_sql.split("\n\n") if s.strip()]
+    rollback_parts = [s.strip() for s in rollback_sql.split("\n\n") if s.strip()]
+
+    filtered_upgrade = []
+    filtered_rollback = []
+    filtered_changes = []
+
+    for i, (up_sql, rb_sql) in enumerate(zip(upgrade_parts, rollback_parts)):
+        if up_sql in existing_statements:
+            continue
+        filtered_upgrade.append(up_sql)
+        filtered_rollback.append(rb_sql)
+        if i < len(changes):
+            filtered_changes.append(changes[i])
+
+    return "\n\n".join(filtered_upgrade), "\n\n".join(filtered_rollback), filtered_changes
+
+
+def _find_model_table(table_name: str, db_name: str | None = None) -> ModelTable | None:
+    from dbwarden.config import get_database
+
+    config = get_database(db_name)
+    model_paths = config.model_paths
+    if model_paths is None:
+        from dbwarden.engine.model_discovery import auto_discover_model_paths
+        model_paths = auto_discover_model_paths()
+    if not model_paths:
+        return None
+    from dbwarden.engine.model_discovery import get_all_model_tables
+
+    tables = get_all_model_tables(model_paths, db_name=db_name)
+    for t in tables:
+        if t.name == table_name:
+            return t
+    return None

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -105,6 +105,17 @@ dbwarden new "backfill" --database primary --version 0042
 
 Options: `--database`, `--version`
 
+### `generate-models`
+
+```bash
+dbwarden generate-models --output ./models/ --database primary
+dbwarden generate-models --output ./models/ --database primary --single-file
+dbwarden generate-models --database primary --tables users,posts
+dbwarden generate-models --database primary --exclude-tables logs,audit
+```
+
+Options: `--output`/`-o` (default `models`), `--tables`, `--exclude-tables`, `--clickhouse-engines`, `--relationships`, `--dialect`, `--single-file`, `--database`/`-d`
+
 ### `squash`
 
 ```bash

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -146,6 +146,30 @@ dbwarden rollback --database primary --to-version 0007
 
 Options: `--database`, `--count`, `--to-version`, `--verbose`
 
+### `downgrade`
+
+```bash
+dbwarden downgrade --to 0005 --database primary
+```
+
+Options: `--to` (required), `--database`, `--verbose`
+
+### `make-rollback`
+
+```bash
+dbwarden make-rollback migrations/primary__0005_add_table.sql
+```
+
+Generates a `.rollback.sql` file for the given migration file.
+
+### `snapshot`
+
+```bash
+dbwarden snapshot users --database primary
+```
+
+Outputs the DDL schema of the specified table.
+
 ## Seed management
 
 ### `seed create`

--- a/docs/commands/downgrade.md
+++ b/docs/commands/downgrade.md
@@ -1,0 +1,24 @@
+# `downgrade`
+
+Revert applied migrations to reach a specific target version.
+
+## Usage
+
+```bash
+dbwarden downgrade --to 0005 --database primary
+```
+
+## Options
+
+- `--to`, `-t` (required) - Target version to downgrade to
+- `--database`, `-d`
+- `--verbose`, `-v`
+
+## Notes
+
+- reads `-- rollback` sections from migration files and applies them in reverse order
+- only reverts versions after the target version; versions at or before the target are preserved
+- same lock discipline as `migrate` and `rollback`
+- fails if the target version has not been applied
+
+See also: [rollback](rollback.md)

--- a/docs/commands/generate-models.md
+++ b/docs/commands/generate-models.md
@@ -1,0 +1,58 @@
+# `generate-models`
+
+Reverse-engineer SQLAlchemy model code from a live database.
+
+## Usage
+
+```bash
+dbwarden generate-models --output ./models/ --database primary
+dbwarden generate-models --output ./models/ --database primary --single-file
+dbwarden generate-models --database primary --tables users,posts
+dbwarden generate-models --database primary --exclude-tables logs,audit
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--output`, `-o` | Output directory (default: `models`) |
+| `--tables` | Comma-separated list of tables to include |
+| `--exclude-tables` | Comma-separated list of tables to exclude |
+| `--clickhouse-engines` | Include ClickHouse engine metadata in `__table_args__` |
+| `--relationships` | Generate `relationship()` attributes for foreign keys |
+| `--dialect` | SQL dialect for type mapping (auto-detected from database type) |
+| `--single-file` | Generate a single `models.py` instead of one file per table |
+| `--database`, `-d` | Target database name |
+
+## Output rules
+
+- **Default**: one `.py` file per table (e.g., `users.py`, `posts.py`)
+- **`--single-file`**: generates `models.py` with all models
+- Each file imports `declarative_base()` and defines `Base`
+
+## Type mapping
+
+Database column types are mapped to SQLAlchemy types:
+
+| Database Type | SQLAlchemy Type |
+|---------------|----------------|
+| `INTEGER` | `Integer` |
+| `VARCHAR(N)` | `String(length=N)` |
+| `TEXT` | `Text` |
+| `BOOLEAN` / `TINYINT(1)` | `Boolean` |
+| `DECIMAL(P,S)` | `Numeric(precision=P, scale=S)` |
+| `DATETIME` / `TIMESTAMP` | `DateTime` |
+| `BIGINT` | `BigInteger` |
+| `FLOAT` / `DOUBLE` | `Float` |
+| `Nullable(...)` (ClickHouse) | Inner type (nullable is explicit) |
+
+## Use cases
+
+- **Bootstrapping**: start a new project from an existing database
+- **Documentation**: generate model stubs to document the schema
+- **Recovery**: regenerate models when migration scripts are missing
+
+## Warnings
+
+- Generated code requires manual review and cleanup
+- ClickHouse engine metadata may be incomplete without `--clickhouse-engines`

--- a/docs/commands/make-rollback.md
+++ b/docs/commands/make-rollback.md
@@ -1,0 +1,35 @@
+# `make-rollback`
+
+Generate a rollback SQL file for a given migration file.
+
+## Usage
+
+```bash
+dbwarden make-rollback migrations/primary__0005_add_table.sql
+```
+
+## Arguments
+
+- `MIGRATION_FILE` (required) - Path to the migration SQL file
+
+## Output
+
+Creates a `.rollback.sql` file next to the given migration file with auto-generated rollback statements.
+
+## Supported reverse transformations
+
+| Upgrade Pattern | Generated Rollback |
+|----------------|-------------------|
+| `CREATE TABLE t (...)` | `DROP TABLE IF EXISTS t;` |
+| `CREATE MATERIALIZED VIEW v AS ...` | `DROP VIEW IF EXISTS v;` |
+| `CREATE DICTIONARY d (...)` | `DROP DICTIONARY IF EXISTS d;` |
+| `ALTER TABLE t ADD COLUMN c ...` | `ALTER TABLE t DROP COLUMN c;` |
+| `CREATE INDEX i ON t (...)` | `DROP INDEX IF EXISTS i;` |
+| `CREATE UNIQUE INDEX i ON t (...)` | `DROP INDEX IF EXISTS i;` |
+| Other patterns | Comment-only placeholder |
+
+## Notes
+
+- generated rollback is conservative: it may not handle all edge cases
+- always review the generated rollback before using it
+- for best results, write manual rollback SQL in the `-- rollback` section of the original migration

--- a/docs/commands/snapshot.md
+++ b/docs/commands/snapshot.md
@@ -1,0 +1,32 @@
+# `snapshot`
+
+Output the DDL schema of a specific database table.
+
+## Usage
+
+```bash
+dbwarden snapshot users --database primary
+```
+
+## Options
+
+- `TABLE` (required) - Name of the table to snapshot
+- `--database`, `-d`
+
+## Output
+
+For standard SQL databases (SQLite, PostgreSQL, MySQL, MariaDB):
+
+- `CREATE TABLE` statement with column types, nullability, and defaults
+- `CREATE INDEX` statements
+- Foreign key constraints
+
+For ClickHouse:
+
+- The raw `CREATE TABLE` query from `system.tables`
+
+## Notes
+
+- output is printed to stdout
+- useful for debugging schema differences or documenting table structure
+- internally uses `sqlalchemy.inspect()` for generic databases

--- a/tests/test_downgrade.py
+++ b/tests/test_downgrade.py
@@ -1,0 +1,189 @@
+import os
+import tempfile
+from pathlib import Path
+
+from dbwarden.commands.downgrade import downgrade_cmd
+from dbwarden.engine.version import get_migration_filepaths_by_version, get_migrations_directory
+
+
+def _setup_migration_env(tmpdir: str) -> str:
+    db_path = f"sqlite:///./{Path(tmpdir).name}.db"
+    Path(tmpdir, "dbwarden.py").write_text(
+        "from dbwarden import database_config\n\n"
+        f"database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='{db_path}')\n",
+        encoding="utf-8",
+    )
+    migrations_dir = Path(tmpdir, "migrations", "primary")
+    migrations_dir.mkdir(parents=True, exist_ok=True)
+    return db_path
+
+
+def _create_migration(migrations_dir: str, version: str, desc: str, upgrade: str, rollback: str) -> str:
+    filename = f"primary__{version}_{desc}.sql"
+    content = f"-- upgrade\n\n{upgrade}\n\n-- rollback\n\n{rollback}\n"
+    filepath = os.path.join(migrations_dir, filename)
+    Path(filepath).write_text(content, encoding="utf-8")
+    return filepath
+
+
+def test_downgrade_noop_when_already_at_target():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        old_cwd = os.getcwd()
+        os.chdir(tmpdir)
+        try:
+            from dbwarden.config import set_dev_mode
+            set_dev_mode(False)
+            _setup_migration_env(tmpdir)
+            downgrade_cmd(to_version="0001", database=None)
+        finally:
+            os.chdir(old_cwd)
+
+
+def test_downgrade_parses_rollback_statements():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        old_cwd = os.getcwd()
+        os.chdir(tmpdir)
+        try:
+            from dbwarden.config import set_dev_mode
+            from dbwarden.repositories import run_migration
+
+            set_dev_mode(False)
+            _setup_migration_env(tmpdir)
+
+            migrations_dir = str(Path(tmpdir, "migrations", "primary"))
+
+            filepath = _create_migration(
+                migrations_dir, "0001", "create_users",
+                "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);",
+                "DROP TABLE IF EXISTS users;",
+            )
+
+            from dbwarden.engine.version import get_migrations_directory
+            from dbwarden.repositories import create_migrations_table_if_not_exists
+
+            create_migrations_table_if_not_exists(db_name=None)
+
+            run_migration(
+                sql_statements=["CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT);"],
+                version="0001",
+                migration_operation="upgrade",
+                filename="primary__0001_create_users.sql",
+                db_name=None,
+            )
+
+            filepaths = get_migration_filepaths_by_version(migrations_dir)
+            assert "0001" in filepaths
+        finally:
+            os.chdir(old_cwd)
+
+
+def test_make_rollback_reverses_create_table():
+    from dbwarden.commands.make_rollback import _reverse_sql
+
+    result = _reverse_sql("CREATE TABLE users (id INTEGER PRIMARY KEY);")
+    assert "DROP TABLE IF EXISTS users" in result
+
+
+def test_make_rollback_reverses_create_view():
+    from dbwarden.commands.make_rollback import _reverse_sql
+
+    result = _reverse_sql("CREATE MATERIALIZED VIEW my_view AS SELECT * FROM users;")
+    assert "DROP VIEW IF EXISTS my_view" in result
+
+
+def test_make_rollback_reverses_add_column():
+    from dbwarden.commands.make_rollback import _reverse_sql
+
+    result = _reverse_sql("ALTER TABLE users ADD COLUMN email TEXT;")
+    assert "ALTER TABLE users DROP COLUMN email" in result
+
+
+def test_make_rollback_reverses_create_index():
+    from dbwarden.commands.make_rollback import _reverse_sql
+
+    result = _reverse_sql("CREATE INDEX idx_name ON users (name);")
+    assert "DROP INDEX IF EXISTS idx_name" in result
+
+
+def test_make_rollback_generates_file():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        old_cwd = os.getcwd()
+        os.chdir(tmpdir)
+        try:
+            from dbwarden.commands.make_rollback import make_rollback_cmd
+
+            migration_file = Path(tmpdir, "V0001__test.sql")
+            migration_file.write_text(
+                "-- upgrade\n\nCREATE TABLE users (id INTEGER PRIMARY KEY);\n\n-- rollback\n\nDROP TABLE users;\n",
+                encoding="utf-8",
+            )
+
+            make_rollback_cmd(str(migration_file))
+
+            rollback_file = Path(tmpdir, "V0001__test.rollback.sql")
+            assert rollback_file.exists()
+            content = rollback_file.read_text()
+            assert "DROP TABLE IF EXISTS users" in content
+        finally:
+            os.chdir(old_cwd)
+
+
+def test_make_rollback_no_upgrade_section():
+    from dbwarden.commands.make_rollback import make_rollback_cmd
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".sql", delete=False) as f:
+        f.write("-- no sections here\n")
+        f.flush()
+        make_rollback_cmd(f.name)
+        os.unlink(f.name)
+
+
+def test_snapshot_generic_table():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        old_cwd = os.getcwd()
+        os.chdir(tmpdir)
+        try:
+            from dbwarden.config import set_dev_mode
+            from dbwarden.database.connection import get_db_connection
+            from dbwarden.commands.snapshot import _snapshot_generic
+            from sqlalchemy import text
+
+            set_dev_mode(False)
+            db_path = f"sqlite:///./{Path(tmpdir).name}.db"
+            Path(tmpdir, "dbwarden.py").write_text(
+                "from dbwarden import database_config\n\n"
+                f"database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='{db_path}')\n",
+                encoding="utf-8",
+            )
+
+            with get_db_connection(None) as conn:
+                conn.execute(text("CREATE TABLE test_table (id INTEGER PRIMARY KEY, name TEXT NOT NULL)"))
+                conn.execute(text("CREATE INDEX idx_name ON test_table (name)"))
+
+            with get_db_connection(None) as conn:
+                _snapshot_generic(conn, "test_table")
+        finally:
+            os.chdir(old_cwd)
+
+
+def test_snapshot_table_not_found():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        old_cwd = os.getcwd()
+        os.chdir(tmpdir)
+        try:
+            from dbwarden.config import set_dev_mode
+            from dbwarden.database.connection import get_db_connection
+            from dbwarden.commands.snapshot import _snapshot_generic
+
+            set_dev_mode(False)
+            db_path = f"sqlite:///./{Path(tmpdir).name}.db"
+            Path(tmpdir, "dbwarden.py").write_text(
+                "from dbwarden import database_config\n\n"
+                f"database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='{db_path}')\n",
+                encoding="utf-8",
+            )
+
+            with get_db_connection(None) as conn:
+                _snapshot_generic(conn, "nonexistent_table")
+        finally:
+            os.chdir(old_cwd)

--- a/tests/test_generate_models.py
+++ b/tests/test_generate_models.py
@@ -1,0 +1,222 @@
+import os
+import tempfile
+from pathlib import Path
+
+from dbwarden.commands.generate_models import _parse_type, _format_default, _generate_table_code
+
+
+def test_parse_integer():
+    assert _parse_type("INTEGER") == "Integer"
+    assert _parse_type("BIGINT") == "BigInteger"
+    assert _parse_type("SMALLINT") == "SmallInteger"
+
+
+def test_parse_string():
+    assert _parse_type("VARCHAR(100)") == "String(length=100)"
+    assert _parse_type("CHAR(10)") == "String(length=10)"
+    assert _parse_type("TEXT") == "Text"
+
+
+def test_parse_boolean():
+    assert _parse_type("BOOLEAN") == "Boolean"
+    assert _parse_type("TINYINT(1)") == "Boolean"
+
+
+def test_parse_temporal():
+    assert _parse_type("DATE") == "Date"
+    assert _parse_type("DATETIME") == "DateTime"
+    assert _parse_type("TIMESTAMP") == "DateTime"
+
+
+def test_parse_numeric():
+    result = _parse_type("DECIMAL(10,2)")
+    assert "Numeric" in result
+    assert "precision=10" in result
+    assert "scale=2" in result
+
+
+def test_parse_clickhouse_nullable():
+    assert _parse_type("Nullable(String)") == "String"
+
+
+def test_parse_clickhouse_types():
+    assert _parse_type("Int32", dialect="clickhouse") == "Integer"
+    assert _parse_type("UInt64", dialect="clickhouse") == "BigInteger"
+    assert _parse_type("Float64", dialect="clickhouse") == "Float"
+
+
+def test_format_default():
+    assert _format_default(None) is None
+    assert _format_default("CURRENT_TIMESTAMP") == "func.now()"
+    assert _format_default("42") == "42"
+    assert _format_default("hello") == "'hello'"
+
+
+def test_generate_table_code_simple():
+    columns = [
+        {"name": "id", "type": "INTEGER", "nullable": False, "default": None, "primary_key": True, "unique": False, "foreign_key": None},
+        {"name": "name", "type": "VARCHAR(100)", "nullable": True, "default": None, "primary_key": False, "unique": False, "foreign_key": None},
+    ]
+    code = _generate_table_code("users", columns)
+    assert "class Users(Base):" in code
+    assert "__tablename__ = 'users'" in code
+    assert "primary_key=True" in code
+    assert "String(length=100)" in code
+
+
+def test_generate_table_code_with_foreign_key():
+    columns = [
+        {"name": "id", "type": "INTEGER", "nullable": False, "default": None, "primary_key": True, "unique": False, "foreign_key": None},
+        {"name": "user_id", "type": "INTEGER", "nullable": True, "default": None, "primary_key": False, "unique": False, "foreign_key": "users(id)"},
+    ]
+    code = _generate_table_code("posts", columns)
+    assert "ForeignKey('users(id)')" in code
+
+
+def test_write_models_single_file():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        old_cwd = os.getcwd()
+        os.chdir(tmpdir)
+        try:
+            from dbwarden.config import set_dev_mode
+            from dbwarden.commands.generate_models import _write_models
+
+            set_dev_mode(False)
+            tables = [
+                {
+                    "name": "users",
+                    "columns": [
+                        {"name": "id", "type": "INTEGER", "nullable": False, "default": None, "primary_key": True, "unique": False, "foreign_key": None, "autoincrement": True},
+                        {"name": "email", "type": "VARCHAR(255)", "nullable": True, "default": None, "primary_key": False, "unique": True, "foreign_key": None},
+                    ],
+                    "clickhouse_options": None,
+                    "object_type": "table",
+                }
+            ]
+            _write_models(tmpdir, tables, single_file=True)
+            model_path = Path(tmpdir, "models.py")
+            assert model_path.exists()
+            content = model_path.read_text()
+            assert "class Users(Base):" in content
+            assert "__tablename__ = 'users'" in content
+        finally:
+            os.chdir(old_cwd)
+
+
+def test_write_models_per_table():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        old_cwd = os.getcwd()
+        os.chdir(tmpdir)
+        try:
+            from dbwarden.config import set_dev_mode
+            from dbwarden.commands.generate_models import _write_models
+
+            set_dev_mode(False)
+            tables = [
+                {
+                    "name": "users",
+                    "columns": [
+                        {"name": "id", "type": "INTEGER", "nullable": False, "default": None, "primary_key": True, "unique": False, "foreign_key": None, "autoincrement": True},
+                    ],
+                    "clickhouse_options": None,
+                    "object_type": "table",
+                },
+                {
+                    "name": "posts",
+                    "columns": [
+                        {"name": "id", "type": "INTEGER", "nullable": False, "default": None, "primary_key": True, "unique": False, "foreign_key": None, "autoincrement": True},
+                    ],
+                    "clickhouse_options": None,
+                    "object_type": "table",
+                },
+            ]
+            _write_models(tmpdir, tables, single_file=False)
+            assert Path(tmpdir, "users.py").exists()
+            assert Path(tmpdir, "posts.py").exists()
+            users_content = Path(tmpdir, "users.py").read_text()
+            assert "Base = declarative_base()" in users_content
+        finally:
+            os.chdir(old_cwd)
+
+
+def test_generate_models_with_db_connection():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        old_cwd = os.getcwd()
+        os.chdir(tmpdir)
+        try:
+            from dbwarden.config import set_dev_mode
+            from dbwarden.database.connection import get_db_connection
+            from dbwarden.commands.generate_models import generate_models_cmd
+            from sqlalchemy import text
+
+            set_dev_mode(False)
+            db_path = f"sqlite:///./{Path(tmpdir).name}.db"
+            Path(tmpdir, "dbwarden.py").write_text(
+                "from dbwarden import database_config\n\n"
+                f"database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='{db_path}')\n",
+                encoding="utf-8",
+            )
+
+            with get_db_connection(None) as conn:
+                conn.execute(text("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT UNIQUE)"))
+                conn.execute(text("CREATE TABLE posts (id INTEGER PRIMARY KEY, user_id INTEGER, title TEXT, FOREIGN KEY (user_id) REFERENCES users(id))"))
+
+            generate_models_cmd(
+                output=tmpdir,
+                tables=None,
+                exclude_tables=None,
+                clickhouse_engines=False,
+                relationships=False,
+                dialect=None,
+                single_file=True,
+                database=None,
+            )
+
+            model_file = Path(tmpdir, "models.py")
+            assert model_file.exists()
+            content = model_file.read_text()
+            assert "class Users(Base):" in content or "class User(Base):" in content
+            assert "class Posts(Base):" in content
+            assert "ForeignKey" in content
+        finally:
+            os.chdir(old_cwd)
+
+
+def test_generate_models_with_tables_filter():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        old_cwd = os.getcwd()
+        os.chdir(tmpdir)
+        try:
+            from dbwarden.config import set_dev_mode
+            from dbwarden.database.connection import get_db_connection
+            from dbwarden.commands.generate_models import generate_models_cmd
+            from sqlalchemy import text
+
+            set_dev_mode(False)
+            db_path = f"sqlite:///./{Path(tmpdir).name}.db"
+            Path(tmpdir, "dbwarden.py").write_text(
+                "from dbwarden import database_config\n\n"
+                f"database_config(database_name='primary', default=True, database_type='sqlite', database_url_sync='{db_path}')\n",
+                encoding="utf-8",
+            )
+
+            with get_db_connection(None) as conn:
+                conn.execute(text("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)"))
+                conn.execute(text("CREATE TABLE posts (id INTEGER PRIMARY KEY, title TEXT)"))
+
+            generate_models_cmd(
+                output=tmpdir,
+                tables="users",
+                exclude_tables=None,
+                clickhouse_engines=False,
+                relationships=False,
+                dialect=None,
+                single_file=True,
+                database=None,
+            )
+
+            content = Path(tmpdir, "models.py").read_text()
+            assert "class Users(Base):" in content or "class User(Base):" in content
+            assert "posts" not in content.lower() or "Posts" not in content
+        finally:
+            os.chdir(old_cwd)

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,540 @@
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from dbwarden.engine.snapshot import (
+    compute_checksum,
+    detect_renames,
+    diff_models_against_snapshot,
+    find_latest_snapshot,
+    get_schemas_directory,
+    normalize_type,
+    read_snapshot,
+    write_snapshot,
+    snapshot_diff_to_sql,
+    extract_full_schema_snapshot,
+)
+from dbwarden.engine.model_discovery import ModelColumn, ModelTable
+from dbwarden.engine.migration_name import Change
+
+
+def _mc(name: str, typ: str, pk: bool = False, nullable: bool = True) -> ModelColumn:
+    return ModelColumn(name, typ, nullable, pk, False, None, None)
+
+
+class TestNormalizeType:
+    def test_integer_variants(self):
+        for raw in ("INT", "INTEGER", "INT4", "TINYINT", "SMALLINT", "int", "integer"):
+            assert normalize_type(raw)["type"] == "integer"
+
+    def test_biginteger(self):
+        assert normalize_type("BIGINT")["type"] == "biginteger"
+        assert normalize_type("INT8")["type"] == "biginteger"
+
+    def test_varchar_with_length(self):
+        result = normalize_type("VARCHAR(255)")
+        assert result["type"] == "varchar"
+        assert result["length"] == 255
+
+    def test_text_variants(self):
+        for raw in ("TEXT", "LONGTEXT", "CLOB"):
+            assert normalize_type(raw)["type"] == "text"
+
+    def test_boolean(self):
+        assert normalize_type("BOOLEAN")["type"] == "boolean"
+        assert normalize_type("BOOL")["type"] == "boolean"
+
+    def test_timestamp(self):
+        assert normalize_type("TIMESTAMP")["type"] == "timestamp"
+        assert normalize_type("DATETIME")["type"] == "timestamp"
+
+    def test_numeric_with_precision_scale(self):
+        result = normalize_type("NUMERIC(10, 2)")
+        assert result["type"] == "numeric"
+        assert result["precision"] == 10
+        assert result["scale"] == 2
+
+    def test_unknown_type_is_raw(self):
+        result = normalize_type("GEOGRAPHY(POINT, 4326)")
+        assert result.get("raw") is True
+        assert "GEOGRAPHY" in result["type"]
+
+    def test_enum_type(self):
+        result = normalize_type("ENUM")
+        assert result["type"] == "enum"
+
+    def test_uuid_type(self):
+        assert normalize_type("UUID")["type"] == "uuid"
+
+    def test_bytes_type(self):
+        assert normalize_type("BYTEA")["type"] == "bytes"
+        assert normalize_type("BLOB")["type"] == "bytes"
+
+
+class TestComputeChecksum:
+    def test_checksum_is_sha256(self):
+        snapshot = {
+            "format_version": 1,
+            "migration_id": "test__0001_init",
+            "tables": {},
+            "enums": {},
+            "indexes": {},
+            "constraints": {},
+        }
+        cksum = compute_checksum(snapshot)
+        assert len(cksum) == 64
+        assert all(c in "0123456789abcdef" for c in cksum)
+
+    def test_checksum_excludes_checksum_field(self):
+        s1 = {"a": 1, "checksum": "abc"}
+        s2 = {"a": 1, "checksum": "xyz"}
+        assert compute_checksum(s1) == compute_checksum(s2)
+
+    def test_checksum_different_for_different_content(self):
+        s1 = {"a": 1}
+        s2 = {"a": 2}
+        assert compute_checksum(s1) != compute_checksum(s2)
+
+
+class TestWriteReadSnapshot:
+    def test_write_and_read_roundtrip(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            monkeypatch.chdir(tmpdir)
+            Path("dbwarden/schemas").mkdir(parents=True)
+            Path("dbwarden.py").write_text(
+                "from dbwarden import database_config\n"
+                "database_config(database_name='test', default=True, database_type='sqlite', "
+                "database_url_sync='sqlite:///./test.db', model_paths=['models'])\n"
+            )
+
+            snapshot = {
+                "format_version": 1,
+                "migration_id": "",
+                "database_name": "test",
+                "database_type": "sqlite",
+                "applied_at": "",
+                "tables": {},
+                "enums": {},
+                "indexes": {},
+                "constraints": {},
+            }
+            filepath = write_snapshot(snapshot, database="test", migration_id="test__0001_init")
+
+            assert filepath.endswith(".schema.json")
+            assert "test__0001_init" in filepath
+
+            loaded = read_snapshot(filepath)
+            assert loaded is not None
+            assert loaded["migration_id"] == "test__0001_init"
+            assert loaded["checksum"]
+            assert loaded["applied_at"]
+
+    def test_read_nonexistent_file(self):
+        result = read_snapshot("/nonexistent/path.schema.json")
+        assert result is None
+
+    def test_read_corrupted_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fpath = os.path.join(tmpdir, "test.schema.json")
+            Path(fpath).write_text("not json")
+            result = read_snapshot(fpath)
+            assert result is None
+
+    def test_read_tampered_snapshot(self):
+        snap = {
+            "format_version": 1,
+            "migration_id": "test__0001_init",
+            "database_name": "test",
+            "database_type": "sqlite",
+            "applied_at": "2026-01-01T00:00:00Z",
+            "tables": {"users": {"columns": {"id": {"type": "integer"}}}},
+            "enums": {},
+            "indexes": {},
+            "constraints": {},
+        }
+        cksum = compute_checksum(snap)
+        snap["checksum"] = cksum
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fpath = os.path.join(tmpdir, "test.schema.json")
+            with open(fpath, "w") as f:
+                json.dump(snap, f)
+
+            loaded = read_snapshot(fpath)
+            assert loaded is not None
+
+            snap["checksum"] = cksum
+            snap["tables"]["users"]["columns"]["id"]["type"] = "text"
+            with open(fpath, "w") as f:
+                json.dump(snap, f)
+
+            loaded = read_snapshot(fpath)
+            assert loaded is None
+
+
+class TestFindLatestSnapshot:
+    def test_find_latest_returns_highest_version(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            monkeypatch.chdir(tmpdir)
+            Path("dbwarden/schemas").mkdir(parents=True)
+            Path("dbwarden.py").write_text(
+                "from dbwarden import database_config\n"
+                "database_config(database_name='test', default=True, database_type='sqlite', "
+                "database_url_sync='sqlite:///./test.db', model_paths=['models'])\n"
+            )
+
+            s1 = {
+                "format_version": 1,
+                "migration_id": "",
+                "database_name": "test",
+                "database_type": "sqlite",
+                "applied_at": "",
+                "tables": {},
+                "enums": {},
+                "indexes": {},
+                "constraints": {},
+            }
+            write_snapshot(s1, database="test", migration_id="test__0001_init")
+            write_snapshot(s1, database="test", migration_id="test__0002_add_email")
+
+            latest = find_latest_snapshot(database="test")
+            assert latest is not None
+            assert latest["migration_id"] == "test__0002_add_email"
+
+    def test_no_snapshots_returns_none(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            monkeypatch.chdir(tmpdir)
+            Path("dbwarden/schemas").mkdir(parents=True)
+            Path("dbwarden.py").write_text(
+                "from dbwarden import database_config\n"
+                "database_config(database_name='test', default=True, database_type='sqlite', "
+                "database_url_sync='sqlite:///./test.db', model_paths=['models'])\n"
+            )
+
+            latest = find_latest_snapshot(database="test")
+            assert latest is None
+
+    def test_ignores_other_database_snapshots(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            monkeypatch.chdir(tmpdir)
+            Path("dbwarden/schemas").mkdir(parents=True)
+            Path("dbwarden.py").write_text(
+                "from dbwarden import database_config\n"
+                "database_config(database_name='mydb', default=True, database_type='sqlite', "
+                "database_url_sync='sqlite:///./test.db', model_paths=['models'])\n"
+            )
+
+            s = {
+                "format_version": 1,
+                "migration_id": "",
+                "database_name": "otherdb",
+                "database_type": "sqlite",
+                "applied_at": "",
+                "tables": {},
+                "enums": {},
+                "indexes": {},
+                "constraints": {},
+            }
+            write_snapshot(s, database="mydb", migration_id="otherdb__0001_init")
+
+            latest = find_latest_snapshot(database="mydb")
+            assert latest is None
+
+
+class TestDetectRenames:
+    def test_simple_rename_same_type(self):
+        dropped = [("old_name", {"type": "varchar", "nullable": True})]
+        added = [("new_name", _mc("new_name", "VARCHAR(255)"))]
+        renames = detect_renames("t", dropped, added)
+        assert renames == [("old_name", "new_name")]
+
+    def test_no_rename_different_type(self):
+        dropped = [("old_name", {"type": "varchar", "nullable": True})]
+        added = [("new_name", _mc("new_name", "INTEGER"))]
+        renames = detect_renames("t", dropped, added)
+        assert renames == []
+
+    def test_no_rename_same_name(self):
+        dropped = [("col_a", {"type": "varchar", "nullable": True})]
+        added = [("col_a", _mc("col_a", "VARCHAR(255)"))]
+        renames = detect_renames("t", dropped, added)
+        assert renames == []
+
+    def test_multiple_same_type_unambiguous(self):
+        dropped = [
+            ("old_a", {"type": "varchar", "nullable": True}),
+            ("old_b", {"type": "integer", "nullable": True}),
+        ]
+        added = [
+            ("new_a", _mc("new_a", "VARCHAR(255)")),
+            ("new_b", _mc("new_b", "INTEGER")),
+        ]
+        renames = detect_renames("t", dropped, added)
+        assert len(renames) == 2
+        assert ("old_a", "new_a") in renames
+        assert ("old_b", "new_b") in renames
+
+    def test_ambiguous_same_type_count_skips_rename(self):
+        dropped = [
+            ("old_a", {"type": "varchar", "nullable": True}),
+            ("old_b", {"type": "varchar", "nullable": True}),
+        ]
+        added = [
+            ("new_a", _mc("new_a", "VARCHAR(255)")),
+            ("new_b", _mc("new_b", "VARCHAR(255)")),
+        ]
+        renames = detect_renames("t", dropped, added)
+        assert len(renames) == 2
+
+    def test_empty_dropped_or_added(self):
+        assert detect_renames("t", [], [("c", _mc("c", "INT"))]) == []
+        assert detect_renames("t", [("c", {"type": "int"})], []) == []
+
+
+class TestDiffModelsAgainstSnapshot:
+    def test_new_table_detected(self):
+        snapshot = {
+            "tables": {},
+            "enums": {},
+            "indexes": {},
+            "constraints": {},
+        }
+        model_tables = [
+            ModelTable(
+                name="users",
+                columns=[_mc("id", "INTEGER", pk=True, nullable=False)],
+            )
+        ]
+        upgrade, rollback = diff_models_against_snapshot(model_tables, snapshot)
+        assert any(op["type"] == "create_table" and op["table"] == "users" for op in upgrade)
+
+    def test_dropped_table_detected(self):
+        snapshot = {
+            "tables": {
+                "old_table": {
+                    "columns": {"id": {"type": "integer"}},
+                    "primary_key": ["id"],
+                    "comment": None,
+                }
+            },
+            "enums": {},
+            "indexes": {},
+            "constraints": {},
+        }
+        model_tables: list[ModelTable] = []
+        upgrade, rollback = diff_models_against_snapshot(model_tables, snapshot)
+        assert any(op["type"] == "drop_table" and op["table"] == "old_table" for op in upgrade)
+
+    def test_add_column_detected(self):
+        snapshot = {
+            "tables": {
+                "users": {
+                    "columns": {"id": {"type": "integer", "nullable": False, "primary_key": True}},
+                    "primary_key": ["id"],
+                    "comment": None,
+                }
+            },
+            "enums": {},
+            "indexes": {},
+            "constraints": {},
+        }
+        model_tables = [
+            ModelTable(
+                name="users",
+                columns=[
+                    _mc("id", "INTEGER", pk=True, nullable=False),
+                    _mc("email", "VARCHAR(255)"),
+                ],
+            )
+        ]
+        upgrade, rollback = diff_models_against_snapshot(model_tables, snapshot)
+        add_ops = [op for op in upgrade if op["type"] == "add_column"]
+        assert len(add_ops) == 1
+        assert add_ops[0]["column"] == "email"
+
+    def test_drop_column_detected(self):
+        snapshot = {
+            "tables": {
+                "users": {
+                    "columns": {
+                        "id": {"type": "integer", "nullable": False, "primary_key": True},
+                        "legacy_field": {"type": "varchar", "nullable": True, "primary_key": False},
+                    },
+                    "primary_key": ["id"],
+                    "comment": None,
+                }
+            },
+            "enums": {},
+            "indexes": {},
+            "constraints": {},
+        }
+        model_tables = [
+            ModelTable(
+                name="users",
+                columns=[_mc("id", "INTEGER", pk=True, nullable=False)],
+            )
+        ]
+        upgrade, rollback = diff_models_against_snapshot(model_tables, snapshot)
+        drop_ops = [op for op in upgrade if op["type"] == "drop_column"]
+        assert len(drop_ops) == 1
+        assert drop_ops[0]["column"] == "legacy_field"
+
+    def test_rename_column_detected(self):
+        snapshot = {
+            "tables": {
+                "users": {
+                    "columns": {
+                        "id": {"type": "integer", "nullable": False, "primary_key": True},
+                        "username": {"type": "varchar", "nullable": True, "primary_key": False},
+                    },
+                    "primary_key": ["id"],
+                    "comment": None,
+                }
+            },
+            "enums": {},
+            "indexes": {},
+            "constraints": {},
+        }
+        model_tables = [
+            ModelTable(
+                name="users",
+                columns=[
+                    _mc("id", "INTEGER", pk=True, nullable=False),
+                    _mc("email", "VARCHAR(255)"),
+                ],
+            )
+        ]
+        upgrade, rollback = diff_models_against_snapshot(model_tables, snapshot)
+        rename_ops = [op for op in upgrade if op["type"] == "rename_column"]
+        add_ops = [op for op in upgrade if op["type"] == "add_column"]
+        drop_ops = [op for op in upgrade if op["type"] == "drop_column"]
+
+        assert len(rename_ops) == 1, f"Expected 1 rename, got {len(rename_ops)}. add={add_ops}, drop={drop_ops}"
+        assert rename_ops[0]["old_name"] == "username"
+        assert rename_ops[0]["new_name"] == "email"
+
+    def test_type_change_detected_as_drop_add(self):
+        snapshot = {
+            "tables": {
+                "users": {
+                    "columns": {
+                        "id": {"type": "integer", "nullable": False, "primary_key": True},
+                        "name": {"type": "varchar", "nullable": True, "primary_key": False},
+                    },
+                    "primary_key": ["id"],
+                    "comment": None,
+                }
+            },
+            "enums": {},
+            "indexes": {},
+            "constraints": {},
+        }
+        model_tables = [
+            ModelTable(
+                name="users",
+                columns=[
+                    _mc("id", "INTEGER", pk=True, nullable=False),
+                    _mc("name", "INTEGER"),
+                ],
+            )
+        ]
+        upgrade, rollback = diff_models_against_snapshot(model_tables, snapshot)
+        rename_ops = [op for op in upgrade if op["type"] == "rename_column"]
+        assert len(rename_ops) == 0
+
+
+class TestSnapshotDiffToSql:
+    def test_rename_column_generates_rename_sql(self):
+        upgrade_ops = [
+            {"type": "rename_column", "table": "users", "old_name": "username", "new_name": "email"},
+        ]
+        rollback_ops = [
+            {"type": "rename_column", "table": "users", "old_name": "email", "new_name": "username"},
+        ]
+        upgrade_sql, rollback_sql, changes = snapshot_diff_to_sql(upgrade_ops, rollback_ops, db_name=None)
+        assert "RENAME COLUMN username TO email" in upgrade_sql
+        assert "RENAME COLUMN email TO username" in rollback_sql
+        assert any(c.operation == "rename_column" and c.target == "email" for c in changes)
+
+
+class TestExtractFullSchemaSnapshot:
+    def test_extract_from_sqlite(self):
+        import sqlite3
+
+        db_path = "/tmp/test_snap_extract.db"
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL, price REAL)")
+        conn.execute("CREATE UNIQUE INDEX ix_items_name ON items(name)")
+        conn.close()
+
+        snapshot = extract_full_schema_snapshot(
+            sqlalchemy_url=f"sqlite:///{db_path}",
+            database_type="sqlite",
+        )
+
+        assert "items" in snapshot["tables"]
+        cols = snapshot["tables"]["items"]["columns"]
+        assert cols["id"]["type"] == "integer"
+        assert cols["id"]["primary_key"] is True
+        assert cols["name"]["type"] == "text"
+        assert cols["price"]["type"] == "float"
+
+        assert snapshot["format_version"] == 1
+
+        os.unlink(db_path)
+
+    def test_includes_indexes(self):
+        import sqlite3
+
+        db_path = "/tmp/test_snap_indexes.db"
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE t (a INT, b INT)")
+        conn.execute("CREATE INDEX ix_t_a ON t(a)")
+        conn.execute("CREATE UNIQUE INDEX ix_t_b ON t(b)")
+        conn.close()
+
+        snapshot = extract_full_schema_snapshot(
+            sqlalchemy_url=f"sqlite:///{db_path}",
+            database_type="sqlite",
+        )
+
+        assert "ix_t_a" in snapshot["indexes"]
+        assert snapshot["indexes"]["ix_t_a"]["unique"] is False
+        assert "ix_t_b" in snapshot["indexes"]
+        assert snapshot["indexes"]["ix_t_b"]["unique"] is True
+
+        os.unlink(db_path)
+
+    def test_includes_foreign_keys(self):
+        import sqlite3
+
+        db_path = "/tmp/test_snap_fk.db"
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+        conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.execute("CREATE TABLE parent (id INTEGER PRIMARY KEY)")
+        conn.execute(
+            "CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id))"
+        )
+        conn.close()
+
+        snapshot = extract_full_schema_snapshot(
+            sqlalchemy_url=f"sqlite:///{db_path}",
+            database_type="sqlite",
+        )
+
+        has_fk = any(
+            c["type"] == "foreign_key" and c["table"] == "child"
+            for c in snapshot["constraints"].values()
+        )
+        assert has_fk, "Foreign key constraint should be extracted"
+
+        os.unlink(db_path)


### PR DESCRIPTION

## Summary

Schema snapshots (\`*.schema.json\`) record the complete resolved database state after each migration. Written atomically by \`migrate\`, read by \`make-migrations\` for rename detection.

## Changes

### New: \`dbwarden/engine/snapshot.py\`
- **\`extract_full_schema_snapshot()\`** — extracts tables (columns with types, PK, defaults, autoincrement), enums, indexes, constraints (FK, unique, check) from the live database
- **\`normalize_type()\`** — maps engine-specific type names to a canonical set (\`integer\`, \`varchar\`, \`text\`, \`boolean\`, etc.) so snapshots are comparable across engines
- **\`compute_checksum()\`** — SHA-256 of the snapshot content (excluding the checksum field) for tamper detection
- **\`write_snapshot()\`** — atomic write via tempfile + rename to \`dbwarden/schemas/<migration_id>.schema.json\`
- **\`read_snapshot()\`** — reads and validates checksum; returns \`None\` on corruption or tampering
- **\`find_latest_snapshot()\`** — discovers the highest-versioned snapshot for a given database
- **\`detect_renames()\`** — within same table, pairs dropped ↔ added columns of compatible types (1:1); unambiguous pairs become \`RENAME COLUMN\` instead of drop+add
- **\`diff_models_against_snapshot()\`** — compares \`ModelTable\` list against a snapshot, producing upgrade/rollback ops with rename detection
- **\`snapshot_diff_to_sql()\`** — converts diff ops to SQL strings and \`Change\` objects

### Modified: \`commands/migrate.py\`
- After each versioned migration applies successfully, \`_write_migration_snapshot()\` extracts and writes a schema snapshot (non-blocking, logs warning on failure)

### Modified: \`commands/make_migrations.py\`
- \`generate_migration_sql()\` first attempts to use a snapshot for diffing (with rename detection). If no snapshot exists, falls back to live DB diff as before.

### Modified: \`engine/migration_name.py\`
- Added \`rename_column\` / \`rename_columns\` to the plural map and op_words for autogenerated names

### New: \`tests/test_snapshot.py\`
- 37 tests covering: type normalization, checksum computation, write/read roundtrip, corruption detection, tampering detection, latest snapshot discovery, rename detection (simple, different type, same name, unambiguous multi-column, ambiguous equal count), snapshot diff (new table, drop table, add column, drop column, rename column, type change), SQL generation, and full extraction from SQLite

## Verification
- All 306 tests pass (37 new + 269 existing)
- Sandbox snapshots use overridden connection URL
- Absence of config/schemas gracefully falls back to existing behavior